### PR TITLE
Cleanup translations, translate installation to German

### DIFF
--- a/locale/de/LC_MESSAGES/design.po
+++ b/locale/de/LC_MESSAGES/design.po
@@ -21,7 +21,6 @@ msgid "Design documents"
 msgstr "Design Dokumente"
 
 #: ../../pages/design/index.md:1
-#, fuzzy
 msgid ""
 "This section contains the resources around the design of the Fortran "
 "Package Manager (fpm)."

--- a/locale/de/LC_MESSAGES/how-to.po
+++ b/locale/de/LC_MESSAGES/how-to.po
@@ -33,7 +33,6 @@ msgid "Installing fpm"
 msgstr "Installation von fpm"
 
 #: ../../pages/how-to/installation.md:3
-#, fuzzy
 msgid ""
 "This how-to guide covers the installation of the Fortran Package Manager "
 "(fpm) on various platforms."
@@ -42,9 +41,8 @@ msgstr ""
 "auf verschiedenen Plattformen."
 
 #: ../../pages/how-to/installation.md:5
-#, fuzzy
 msgid "{fab}`apple` {fab}`linux` {fab}`windows` Download binaries"
-msgstr "{fab}`apple` {fab}`linux` Conda Paketverwaltung"
+msgstr "{fab}`apple` {fab}`linux` {fab}`windows` Program herunterladen"
 
 #: ../../pages/how-to/installation.md:7
 msgid ""
@@ -52,6 +50,10 @@ msgid ""
 "download for each release of fpm, as well as the latest (bleeding edge) "
 "release which mirrors the latest commit in the main branch of fpm."
 msgstr ""
+"Für macOS, Linux und Windows (alles auf x86-64) sind Binärdateien "
+"verfügbar, die für jede Version von fpm verfügbar sind, sowie die "
+"neueste (Bleeding Edge) Version, die die aktuellste Version des fpm-Main-Branches "
+"speichert."
 
 #: ../../pages/how-to/installation.md:9
 msgid ""
@@ -63,6 +65,14 @@ msgid ""
 "downloading, you will need to make your binary executable. On Linux and "
 "macOS, you can do this by typing"
 msgstr ""
+"Gehe zu [fpm Releases](https://github.com/fortran-lang/fpm/releases) "
+"um alle verfügbaren Releases zu sehen. Die herunterladbaren Dateien sind "
+"unter *Assets* in jedem Release-Abschnitt verfügbar. Klick auf "
+"den entsprechenden Link, der dem gewünschten Betriebssystem entspricht. "
+"Zum Beispiel, um ein fpm-Binary für macOS herunterzuladen, klicke auf den "
+"Link, der *macos* in seinem Namen enthält. Nach dem Herunterladen muss "
+"das heruntergeladene Programm ausführbar gemacht werden. Auf Linux und "
+"macOS kann dies folgendermaßen erreicht werden"
 
 #: ../../pages/how-to/installation.md:20
 msgid ""
@@ -70,12 +80,17 @@ msgid ""
 "(*i.e.* in the ``PATH`` environment variable on Linux and macOS). You can"
 " also rename the binary to just *fpm* for easier use."
 msgstr ""
+"Optional, stelle das Binary in einem Verzeichnis, das global zugänglich ist "
+"(*z.B.* in der ``PATH``-Variable auf Linux und macOS). Um das Binary einfacher "
+"verwendbar zu machen kann es auch in *fpm* umbenannt werden."
 
 #: ../../pages/how-to/installation.md:23
 msgid ""
 "For Windows, both a self-contained binary and a Windows Installer for fpm"
 " are available."
 msgstr ""
+"Für Windows sind sowohl ein selbstverständliches Binary als auch ein "
+"Windows-Installer für fpm verfügbar."
 
 #: ../../pages/how-to/installation.md:1
 msgid ""
@@ -84,6 +99,11 @@ msgid ""
 "verify the integrity of the downloaded binary the checksum can be "
 "computed locally and compared with the one provided in the release"
 msgstr ""
+"Links, die mit ``.sha256`` enden, stellen die kryptographische Hashes "
+"dar, um zu verifizieren, ob die Herunterladen des Binaries erfolgreich war. "
+"Um die Integrität des heruntergeladenen Binaries zu verifizieren kann die "
+"Prüfsumme lokal berechnet und mit der im Release angegebenen Prüfsumme "
+"verglichen werden."
 
 #: ../../pages/how-to/installation.md:11
 msgid ""
@@ -91,6 +111,10 @@ msgid ""
 "the binary non-functional. In this case, retry the download of the binary"
 " and confirm that the checksums match."
 msgstr ""
+"Wenn die Prüfsummen nicht übereinstimmen, war die Herunterladen des "
+"Binaries nicht erfolgreich. In diesem Fall kann es erneut versucht werden, "
+"die Binaries herunterzuladen und zu verifizieren, dass die Prüfsummen "
+"übereinstimmen."
 
 #: ../../pages/how-to/installation.md:41
 msgid "{fab}`windows` MSYS2 package manager"
@@ -119,7 +143,6 @@ msgstr ""
 "sind [hier](https://www.msys2.org/docs/terminals/) verfügbar)."
 
 #: ../../pages/how-to/installation.md:4
-#, fuzzy
 msgid ""
 "The Fortran Package Manager is supported for the the *UCRT64*, *MinGW64*,"
 " or *MinGW32* terminal."
@@ -161,7 +184,6 @@ msgid "{fab}`apple` Homebrew package manager"
 msgstr "{fab}`apple` Homebrew Paketverwaltung"
 
 #: ../../pages/how-to/installation.md:74
-#, fuzzy
 msgid ""
 "The Fortran Package Manager (fpm) is available for the "
 "[homebrew](https://brew.sh) package manager on MacOS via an additional "
@@ -226,7 +248,6 @@ msgid "{fab}`linux` Arch Linux user repository"
 msgstr "{fab}`linux` Arch Linux Nutzer Repository"
 
 #: ../../pages/how-to/installation.md:120
-#, fuzzy
 msgid ""
 "The Arch Linux user repository (AUR) contains two packages for the "
 "Fortran Package Manager (fpm). With the [fortran-fpm-"

--- a/locale/de/LC_MESSAGES/index.po
+++ b/locale/de/LC_MESSAGES/index.po
@@ -33,7 +33,6 @@ msgid "Reference"
 msgstr "Referenz"
 
 #: ../../pages/index.md:1 ../../pages/index.md:5
-#, fuzzy
 msgid "Fortran Package Manager"
 msgstr "Fortran-Paketmanager"
 
@@ -42,7 +41,6 @@ msgid "Package manager and build system for Fortran"
 msgstr "Paketmanager und Build-System für Fortran"
 
 #: ../../pages/index.md:19
-#, fuzzy
 msgid ""
 "Welcome to the documentation for the Fortran Package Manager (fpm). This "
 "documentation is divided in four parts. Select one of the topics below to"
@@ -125,7 +123,6 @@ msgid "{fa}`newspaper` News"
 msgstr "{fa}`newspaper` Aktuelles"
 
 #: ../../pages/index.md:124
-#, fuzzy
 msgid ""
 "Recent events around the Fortran Package Manager, such as new releases, "
 "conference talks, and new packages will be announced here."

--- a/locale/de/LC_MESSAGES/spec.po
+++ b/locale/de/LC_MESSAGES/spec.po
@@ -25,7 +25,6 @@ msgid "Specifications and Reference"
 msgstr "Spezifikationen und Referenz"
 
 #: ../../pages/spec/index.md:1
-#, fuzzy
 msgid ""
 "This section contains the specifications the components of the Fortran "
 "Package Manager."
@@ -34,7 +33,6 @@ msgstr ""
 "Paketmanagers."
 
 #: ../../pages/spec/index.md:1
-#, fuzzy
 msgid ""
 "The generated API documentation of the fpm internals can be found "
 "[here](https://fortran-lang.github.io/fpm)."

--- a/locale/de/LC_MESSAGES/tutorial.po
+++ b/locale/de/LC_MESSAGES/tutorial.po
@@ -235,7 +235,6 @@ msgid "First steps with fpm"
 msgstr "Erste Schritte mit fpm"
 
 #: ../../pages/tutorial/hello-fpm.md:3
-#, fuzzy
 msgid ""
 "This tutorial covers the basic usage of the Fortran Package Manager (fpm)"
 " command line. It will cover the generation of a new project and the "
@@ -331,7 +330,6 @@ msgid "Tutorials"
 msgstr "Kurse"
 
 #: ../../pages/tutorial/index.md:1
-#, fuzzy
 msgid ""
 "This section contains courses for learning about the usage and fpm at "
 "specific examples."

--- a/locale/es/LC_MESSAGES/design.po
+++ b/locale/es/LC_MESSAGES/design.po
@@ -21,7 +21,6 @@ msgid "Design documents"
 msgstr "Documentos de diseño"
 
 #: ../../pages/design/index.md:1
-#, fuzzy
 msgid ""
 "This section contains the resources around the design of the Fortran "
 "Package Manager (fpm)."

--- a/locale/es/LC_MESSAGES/how-to.po
+++ b/locale/es/LC_MESSAGES/how-to.po
@@ -33,7 +33,6 @@ msgid "Installing fpm"
 msgstr "Instalación de fpm"
 
 #: ../../pages/how-to/installation.md:3
-#, fuzzy
 msgid ""
 "This how-to guide covers the installation of the Fortran Package Manager "
 "(fpm) on various platforms."
@@ -42,9 +41,8 @@ msgstr ""
 "Fortran (fpm) en diversas plataformas."
 
 #: ../../pages/how-to/installation.md:5
-#, fuzzy
 msgid "{fab}`apple` {fab}`linux` {fab}`windows` Download binaries"
-msgstr "{fab}`apple` {fab}`linux` Administrador de paquetes Conda"
+msgstr ""
 
 #: ../../pages/how-to/installation.md:7
 msgid ""
@@ -120,7 +118,6 @@ msgstr ""
 "[aquí](https://www.msys2.org/docs/terminals/))."
 
 #: ../../pages/how-to/installation.md:4
-#, fuzzy
 msgid ""
 "The Fortran Package Manager is supported for the the *UCRT64*, *MinGW64*,"
 " or *MinGW32* terminal."
@@ -163,7 +160,6 @@ msgid "{fab}`apple` Homebrew package manager"
 msgstr "{fab}`apple` Administrador de paquetes Homebrew"
 
 #: ../../pages/how-to/installation.md:74
-#, fuzzy
 msgid ""
 "The Fortran Package Manager (fpm) is available for the "
 "[homebrew](https://brew.sh) package manager on MacOS via an additional "
@@ -227,7 +223,6 @@ msgid "{fab}`linux` Arch Linux user repository"
 msgstr "{fab}`linux` Repositorio de usuarios de Arch Linux"
 
 #: ../../pages/how-to/installation.md:120
-#, fuzzy
 msgid ""
 "The Arch Linux user repository (AUR) contains two packages for the "
 "Fortran Package Manager (fpm). With the [fortran-fpm-"

--- a/locale/es/LC_MESSAGES/index.po
+++ b/locale/es/LC_MESSAGES/index.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: fpm \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-12-16 00:25+0100\n"
-"PO-Revision-Date: 2021-12-01 12:38+0100\n"
+"PO-Revision-Date: 2021-12-18 12:38+0100\n"
 "Last-Translator: Asdrubal Lozada-Blanco <aslozada@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -41,31 +41,31 @@ msgid "Package manager and build system for Fortran"
 msgstr "Administrador de paquetes y sistema de construcción para Fortran"
 
 #: ../../pages/index.md:19
-#, fuzzy
+
 msgid ""
 "Welcome to the documentation for the Fortran Package Manager (fpm). This "
 "documentation is divided in four parts. Select one of the topics below to"
 " continue."
 msgstr ""
 "Bienvenido a la documentación del Administrador de paquetes de Fortran "
-"(fpm). Esta documentación está dividida en cuatro partes principales, "
+"(fpm). Esta documentación está dividida en cuatro partes, "
 "seleccione uno de los tópicos abajo para continuar."
 
 #: ../../pages/index.md:1
-#, fuzzy
+
 msgid ""
 "These pages are currently under construction. Please help us improve them"
 " by contributing content or reporting issues."
 msgstr ""
-"¡Estas páginas están actualmente en construcción y sus contribuciones son"
-" siempre bienvenidas!"
+"Estas páginas están actualmente en construcción. Por favor ayudanos a mejorarla "
+"contribuyendo con contenido o reportando fallas."
 
 #: ../../pages/index.md:1
 msgid "{octicon}`mortar-board` Tutorials"
 msgstr "{octicon}`mortar-board` Tutoriales"
 
 #: ../../pages/index.md:2
-#, fuzzy
+
 msgid ""
 "Learn about using fpm for Fortran development, creating projects and "
 "managing dependencies."
@@ -82,7 +82,7 @@ msgid "{octicon}`book` How-To Guides"
 msgstr "{octicon}`book` Guías prácticas"
 
 #: ../../pages/index.md:2
-#, fuzzy
+
 msgid "Practical guides and recipes to solve specific problems with fpm"
 msgstr "Guías prácticas y recetas para resolver problemas específicos con fpm."
 
@@ -95,7 +95,7 @@ msgid "{octicon}`milestone` Design Documents"
 msgstr "{octicon}`milestone` Documentos de diseño"
 
 #: ../../pages/index.md:2
-#, fuzzy
+
 msgid ""
 "Resources about the design of the command line interface, the package "
 "manifest, and the general user experience"
@@ -113,7 +113,7 @@ msgstr "{octicon}`gear` Referencias"
 
 #: ../../pages/index.md:2
 msgid "Specifications of fpm components and implementation references"
-msgstr ""
+msgstr "Especificación de componentes de fpm y referencias de implementación"
 
 #: ../../pages/index.md:1
 msgid "Browse references"
@@ -124,7 +124,7 @@ msgid "{fa}`newspaper` News"
 msgstr "{fa}`newspaper` Noticias"
 
 #: ../../pages/index.md:124
-#, fuzzy
+
 msgid ""
 "Recent events around the Fortran Package Manager, such as new releases, "
 "conference talks, and new packages will be announced here."

--- a/locale/es/LC_MESSAGES/index.po
+++ b/locale/es/LC_MESSAGES/index.po
@@ -33,12 +33,10 @@ msgid "Reference"
 msgstr "Referencia"
 
 #: ../../pages/index.md:1 ../../pages/index.md:5
-#, fuzzy
 msgid "Fortran Package Manager"
 msgstr "Administrador de paquetes de Fortran"
 
 #: ../../pages/index.md:2
-#, fuzzy
 msgid "Package manager and build system for Fortran"
 msgstr "Administrador de paquetes y sistema de construcción para Fortran"
 

--- a/locale/es/LC_MESSAGES/spec.po
+++ b/locale/es/LC_MESSAGES/spec.po
@@ -25,7 +25,6 @@ msgid "Specifications and Reference"
 msgstr "Especificaciones y referencia"
 
 #: ../../pages/spec/index.md:1
-#, fuzzy
 msgid ""
 "This section contains the specifications the components of the Fortran "
 "Package Manager."
@@ -34,7 +33,6 @@ msgstr ""
 "Administrador de paquetes de Fortran."
 
 #: ../../pages/spec/index.md:1
-#, fuzzy
 msgid ""
 "The generated API documentation of the fpm internals can be found "
 "[here](https://fortran-lang.github.io/fpm)."

--- a/locale/es/LC_MESSAGES/tutorial.po
+++ b/locale/es/LC_MESSAGES/tutorial.po
@@ -233,7 +233,6 @@ msgid "First steps with fpm"
 msgstr "Primeros pasos con fpm"
 
 #: ../../pages/tutorial/hello-fpm.md:3
-#, fuzzy
 msgid ""
 "This tutorial covers the basic usage of the Fortran Package Manager (fpm)"
 " command line. It will cover the generation of a new project and the "
@@ -326,7 +325,6 @@ msgid "Tutorials"
 msgstr "Tutoriales"
 
 #: ../../pages/tutorial/index.md:1
-#, fuzzy
 msgid ""
 "This section contains courses for learning about the usage and fpm at "
 "specific examples."

--- a/locale/zh_CN/LC_MESSAGES/design.po
+++ b/locale/zh_CN/LC_MESSAGES/design.po
@@ -22,7 +22,6 @@ msgid "Design documents"
 msgstr "设计文档"
 
 #: ../../pages/design/index.md:1
-#, fuzzy
 msgid ""
 "This section contains the resources around the design of the Fortran "
 "Package Manager (fpm)."

--- a/locale/zh_CN/LC_MESSAGES/how-to.po
+++ b/locale/zh_CN/LC_MESSAGES/how-to.po
@@ -32,16 +32,14 @@ msgid "Installing fpm"
 msgstr "安装fpm"
 
 #: ../../pages/how-to/installation.md:3
-#, fuzzy
 msgid ""
 "This how-to guide covers the installation of the Fortran Package Manager "
 "(fpm) on various platforms."
 msgstr "本操作指南涵盖了在各种平台上安装Fortran包管理器（fpm）的过程。"
 
 #: ../../pages/how-to/installation.md:5
-#, fuzzy
 msgid "{fab}`apple` {fab}`linux` {fab}`windows` Download binaries"
-msgstr "{fab}`apple` {fab}`linux` Conda包管理器"
+msgstr ""
 
 #: ../../pages/how-to/installation.md:7
 msgid ""
@@ -109,7 +107,6 @@ msgid ""
 msgstr "要安装``msys2-x86_64-YYYYMMDD.exe``，请从MSYS2网页下载安装程序并运行它。MSYS2将创建几个新的桌面快捷方式，如*MSYS*终端，*MinGW64*终端和*UCRT64*终端（有关MSYS2终端的更多信息可在[此处](https://www.msys2.org/docs/terminals/)获得）"
 
 #: ../../pages/how-to/installation.md:4
-#, fuzzy
 msgid ""
 "The Fortran Package Manager is supported for the the *UCRT64*, *MinGW64*,"
 " or *MinGW32* terminal."
@@ -143,7 +140,6 @@ msgid "{fab}`apple` Homebrew package manager"
 msgstr "{fab}`apple` Homebrew包管理器"
 
 #: ../../pages/how-to/installation.md:74
-#, fuzzy
 msgid ""
 "The Fortran Package Manager (fpm) is available for the "
 "[homebrew](https://brew.sh) package manager on MacOS via an additional "
@@ -197,7 +193,6 @@ msgid "{fab}`linux` Arch Linux user repository"
 msgstr "{fab}`linux` Arch Linux用户存储库"
 
 #: ../../pages/how-to/installation.md:120
-#, fuzzy
 msgid ""
 "The Arch Linux user repository (AUR) contains two packages for the "
 "Fortran Package Manager (fpm). With the [fortran-fpm-"

--- a/locale/zh_CN/LC_MESSAGES/index.po
+++ b/locale/zh_CN/LC_MESSAGES/index.po
@@ -34,12 +34,10 @@ msgid "Reference"
 msgstr "参考"
 
 #: ../../pages/index.md:1 ../../pages/index.md:5
-#, fuzzy
 msgid "Fortran Package Manager"
 msgstr "Fortran包管理器"
 
 #: ../../pages/index.md:2
-#, fuzzy
 msgid "Package manager and build system for Fortran"
 msgstr "适用Fortran的包管理器和构建系统"
 

--- a/locale/zh_CN/LC_MESSAGES/spec.po
+++ b/locale/zh_CN/LC_MESSAGES/spec.po
@@ -26,14 +26,12 @@ msgid "Specifications and Reference"
 msgstr "规范和参考"
 
 #: ../../pages/spec/index.md:1
-#, fuzzy
 msgid ""
 "This section contains the specifications the components of the Fortran "
 "Package Manager."
 msgstr "本节包含Fortran包管理器组件的规范。"
 
 #: ../../pages/spec/index.md:1
-#, fuzzy
 msgid ""
 "The generated API documentation of the fpm internals can be found "
 "[here](https://fortran-lang.github.io/fpm)."

--- a/locale/zh_CN/LC_MESSAGES/tutorial.po
+++ b/locale/zh_CN/LC_MESSAGES/tutorial.po
@@ -192,7 +192,6 @@ msgid "First steps with fpm"
 msgstr "使用fpm的第一步"
 
 #: ../../pages/tutorial/hello-fpm.md:3
-#, fuzzy
 msgid ""
 "This tutorial covers the basic usage of the Fortran Package Manager (fpm)"
 " command line. It will cover the generation of a new project and the "


### PR DESCRIPTION
- removes fuzzy attributes from all msgid's which contain Fortran Package Manager (aftermath from #29).
- translate downloading fpm binaries to German (see #28)