### PR TITLE
Link to the fpm packages index?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 .PHONY: help $(MAKEFILES)
 
 html: $(addprefix html/,$(LANGUAGES)) $(BUILDDIR)/html/index.html
+	@echo "Pages available at file://$$PWD/$(BUILDDIR)/html/index.html"
 
 $(addprefix html/,$(LANGUAGES)): $(MAKEFILES)
 	@$(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)/$@" $(SPHINXOPTS) -Dlanguage=$(word 2,$(subst /, ,$@))

--- a/pages/index.md
+++ b/pages/index.md
@@ -141,5 +141,6 @@ Tutorial <tutorial/index>
 How-To <how-to/index>
 Design <design/index>
 Reference <spec/index>
+Registry <https://fortran-lang.org/packages/fpm>
 news
 ````

--- a/pages/index.md
+++ b/pages/index.md
@@ -18,11 +18,8 @@ Package manager and build system for Fortran
 
 Welcome to the documentation for the Fortran Package Manager (fpm).
 
-This fpm documentation is divided into four parts.
-Select one of the topics below to continue to explore and learn more about fpm.
-
-There are many [Fortran Packages](https://fortran-lang.org/packages/) available 
-for use with fpm, providing an easiliy accessable and rich ecosystem of high-performance code. 
+This documentation is divided into four parts.
+Select one of the topics below to continue.
 
 ::::{note}
 These pages are currently under construction.
@@ -122,6 +119,13 @@ Browse references
 ::::
 
 :::::
+
+## {fa}`cubes` Registry
+
+There are already many packages available for use with fpm, providing an easily accessible and rich ecosystem of general purpose and high-performance code.
+For a full list of packages checkout the [fpm registry](https://fortran-lang.org/packages/fpm).
+New packages can be submitted to the registry [here](https://github.com/fortran-lang/fpm-registry).
+
 
 ## {fa}`newspaper` News
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -17,8 +17,12 @@ Package manager and build system for Fortran
 :::
 
 Welcome to the documentation for the Fortran Package Manager (fpm).
-This documentation is divided in four parts.
-Select one of the topics below to continue.
+
+This fpm documentation is divided into four parts.
+Select one of the topics below to continue to explore and learn more about fpm.
+
+There are many [Fortran Packages](https://fortran-lang.org/packages/) available 
+for use with fpm, providing an easiliy accessable and rich ecosystem of high-performance code. 
 
 ::::{note}
 These pages are currently under construction.


### PR DESCRIPTION
Apologies if I missed it - but I could not see a link to the fpm packages index from this page? As fpm enables the use of packages, and there is a good index available of packages to use with fpm, I thought it would be good to link to it...

Suggested word are just that - so feel free to alter if you agree this link would be useful for others.

Thanks

Simon