### PR TITLE
Japanese translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Minimal makefile for Sphinx documentation
 
 # You can set these variables from the command line.
-LANGUAGES     ?= en de zh_CN es fr nl
+LANGUAGES     ?= en de zh_CN es fr nl ja
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SPHINXINTL    ?= sphinx-intl

--- a/locale/ja/LC_MESSAGES/design.po
+++ b/locale/ja/LC_MESSAGES/design.po
@@ -1,0 +1,48 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 Fortran programming language community
+# This file is distributed under the same license as the fpm package.
+# Tomohiro Degawa <degawa.tomohiro@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: fpm \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-20 15:35+0900\n"
+"PO-Revision-Date: 2022-03-22 20:58+0900\n"
+"Last-Translator: 出川智啓 <degawa.tomohiro@gmail.com>\n"
+"Language-Team: degawa <https://gihub.com/degawa>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../pages/design/index.md:3
+msgid "Design documents"
+msgstr "設計文書"
+
+#: ../../pages/design/index.md:6
+msgid ""
+"This section contains the resources around the design of the Fortran "
+"Package Manager (fpm)."
+msgstr ""
+"ここには，Fortranパッケージマネージャ（fpm）の設計に関する情報が掲載されています．"
+
+#: ../../pages/design/index.md:9
+msgid ""
+"Fortran Package Manager (fpm) is a package manager and build system for "
+"Fortran. Its key goal is to improve the user experience of Fortran "
+"programmers. It does so by making it easier to build your Fortran program"
+" or library, run the executables, tests, and examples, and distribute it "
+"as a dependency to other Fortran projects. Fpm's user interface is "
+"modeled after [Rust's Cargo](https://doc.rust-lang.org/cargo/). Its long "
+"term vision is to nurture and grow the ecosystem of modern Fortran "
+"applications and libraries."
+msgstr ""
+"Fortranパッケージマネージャ（fpm）は，Fortran用のパッケージ管理およびビルドシステムです．"
+"その主要な目標は，Fortranプログラマのユーザ体験を改善することです．"
+"Fortranプログラムおよびライブラリのビルド，実行ファイル・テスト・サンプルプログラムの実行，"
+"他のFortranプロジェクトの依存関係としての配布を容易にすることで，使用感の改善を実現します．"
+"Fpmのユーザインタフェースは，[RustのCargo](https://doc.rust-lang.org/cargo/)を参考にしています．"
+"Fpmの長期的な展望は，現代的なFortranのアプリケーションおよびライブラリのエコシステムを"
+"涵養し，成長させることです．"

--- a/locale/ja/LC_MESSAGES/how-to.po
+++ b/locale/ja/LC_MESSAGES/how-to.po
@@ -231,7 +231,7 @@ msgid ""
 msgstr ""
 "condaパッケージ管理システムは，"
 "[miniforge](https://github.com/conda-forge/miniforge/releases)もしくは"
-"[miniforge](https://github.com/conda-forge/miniforge/releases)から"
+"[miniconda](https://docs.conda.io/en/latest/miniconda.html)から"
 "インストールできます．"
 
 #: ../../pages/how-to/installation.md:118

--- a/locale/ja/LC_MESSAGES/how-to.po
+++ b/locale/ja/LC_MESSAGES/how-to.po
@@ -1,0 +1,337 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 Fortran programming language community
+# This file is distributed under the same license as the fpm package.
+# Tomohiro Degawa <degawa.tomohiro@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: fpm \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-20 15:35+0900\n"
+"PO-Revision-Date: 2022-03-22 20:58+0900\n"
+"Last-Translator: 出川智啓 <degawa.tomohiro@gmail.com>\n"
+"Language-Team: degawa <https://github.com/degawa>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../pages/how-to/index.md:3
+msgid "How-To guides"
+msgstr "利用方法"
+
+#: ../../pages/how-to/index.md:6
+msgid ""
+"This section contains practical guides and recipes for solving specific "
+"problems with fpm."
+msgstr "ここには，fpmを用いて具体的な問題を解決する実践的な方法や秘訣が掲載されています．"
+
+#: ../../pages/how-to/installation.md:1
+msgid "Installing fpm"
+msgstr "fpmのインストール"
+
+#: ../../pages/how-to/installation.md:3
+msgid ""
+"This how-to guide covers the installation of the Fortran Package Manager "
+"(fpm) on various platforms."
+msgstr ""
+"この利用方法では，様々なプラットフォームへのFortranパッケージマネージャ（fpm）のインストール方法を取り扱います．"
+
+#: ../../pages/how-to/installation.md:5
+msgid "{fab}`apple` {fab}`linux` {fab}`windows` Download binaries"
+msgstr "{fab}`apple` {fab}`linux` {fab}`windows` バイナリのダウンロード"
+
+#: ../../pages/how-to/installation.md:7
+msgid ""
+"Binaries for macOS, Linux, and Windows (all on x86-64) are available for "
+"download for each release of fpm, as well as the latest (bleeding edge) "
+"release which mirrors the latest commit in the main branch of fpm."
+msgstr ""
+"fpmの各リリースにおける，macOS，Linux，およびWindows向けのバイナリ（全てx86-64）をダウンロード可能です．"
+"また，fpmのmainブランチ内の最新コミットを反映した試作的な最新開発版もダウンロードできます．"
+
+#: ../../pages/how-to/installation.md:9
+msgid ""
+"Navigate to [fpm releases](https://github.com/fortran-lang/fpm/releases) "
+"to see all available releases. The downloadable files are available at "
+"the bottom of each release section under *Assets*. Click on the "
+"appropriate link based on your OS. For example, to download a macOS fpm "
+"binary, click on the link that has *macos* in its name. After "
+"downloading, you will need to make your binary executable. On Linux and "
+"macOS, you can do this by typing"
+msgstr ""
+"[fpm releases](https://github.com/fortran-lang/fpm/releases)に移動すると，"
+"利用可能な全てのリリースを確認できます，ダウンロード可能なファイルは，"
+"各リリース項目の下部にある*Assets*に表示されます．利用しているOSに応じて，"
+"適切なリンクをクリックしてください．例えば，macOS向けのfpmバイナリをダウンロードするには，"
+"名前に*macos*が含まれているリンクをクリックします．ダウンロードした後，"
+"バイナリを実行可能にする必要があります．LinuxまたはmacOSでは，"
+"下記のコマンドを実行します．"
+
+
+#: ../../pages/how-to/installation.md:20
+msgid ""
+"Optionally, place the binary in a directory that is globally accessible "
+"(*i.e.* in the ``PATH`` environment variable on Linux and macOS). You can"
+" also rename the binary to just *fpm* for easier use."
+msgstr ""
+"任意の作業として，どこからでもアクセス可能なディレクトリ"
+"（つまり，LinuxとmacOSでは，``PATH``環境変数で指定されたディレクトリ）にバイナリを配置します．"
+"使いやすいように，名前を*fpm*のみに変更できます．"
+
+#: ../../pages/how-to/installation.md:23
+msgid ""
+"For Windows, both a self-contained binary and a Windows Installer for fpm"
+" are available."
+msgstr ""
+"Windowsでは，fpmのバイナリだけでなく，インストーラも利用できます．"
+
+#: ../../pages/how-to/installation.md:26
+msgid ""
+"Links that end with ``.sha256`` provide the cryptographic hashes that you"
+" can use to verify if the download of your binary was successful. To "
+"verify the integrity of the downloaded binary the checksum can be "
+"computed locally and compared with the one provided in the release"
+msgstr ""
+"末尾が``.sha256``のリンクは暗号学的ハッシュを提供しており，"
+"バイナリのダウンロードが成功したかの検証に利用できます．"
+"ダウンロードしたバイナリの整合性を検証するために，チェックサムを計算し，"
+"fpm releasesで提供されているハッシュと比較してください．"
+
+#: ../../pages/how-to/installation.md:36
+msgid ""
+"If the checksums mismatch, the download was most likely incomplete and "
+"the binary non-functional. In this case, retry the download of the binary"
+" and confirm that the checksums match."
+msgstr ""
+"もしチェックサムが一致しないなら，ダウンロードが不完全の可能性が高く，バイナリは動作しないでしょう．"
+"バイナリのダウンロードを再試行し，チェックサムが一致することを確認してください．"
+
+#: ../../pages/how-to/installation.md:41
+msgid "{fab}`windows` MSYS2 package manager"
+msgstr "{fab}`windows` MSYS2パッケージ管理システムの利用"
+
+#: ../../pages/how-to/installation.md:43
+msgid ""
+"The [MSYS2 project](https://www.msys2.org) provides a package manager and"
+" makes many common Unix tools available for Windows."
+msgstr ""
+"[MSYS2プロジェクト](https://www.msys2.org)はパッケージ管理システムを提供しており，"
+"Unixにおける共通したツールの多くをWindowsで利用できるようにします．"
+
+#: ../../pages/how-to/installation.md:46
+msgid ""
+"To install download the ``msys2-x86_64-YYYYMMDD.exe`` installer from the "
+"MSYS2 webpage and run it. MSYS2 will create several new desktop "
+"shortcuts, like *MSYS terminal*, *MinGW64 terminal* and *UCRT64 terminal*"
+" (more information on MSYS2 terminals are available "
+"[here](https://www.msys2.org/docs/terminals/))."
+msgstr ""
+"インストールするには，MSYS2のウェブページからインストーラ``msys2-x86_64-YYYYMMDD.exe``を"
+"ダウンロードし，それを実行します．MSYS2は，*MSYS terminal*, *MinGW64 terminal*, *UCRT64 terminal*"
+"などのいくつかの新しいデスクトップショートカットを作成します．"
+"（MSYS2の端末の詳細は，[こちら](https://www.msys2.org/docs/terminals/)を参照してください）"
+
+#: ../../pages/how-to/installation.md:49
+msgid ""
+"The Fortran Package Manager is supported for the the *UCRT64*, *MinGW64*,"
+" or *MinGW32* terminal."
+msgstr ""
+"Fortranパッケージマネージャは，*UCRT64*, *MinGW64*, *MinGW32* terminalで利用できます．"
+
+#: ../../pages/how-to/installation.md:52
+msgid "Open a new terminal and update your installation with"
+msgstr "新しい端末を開き，次のコマンドを用いて更新してください．"
+
+#: ../../pages/how-to/installation.md:58
+msgid ""
+"You might have to update MSYS2 and ``pacman`` first, restart the terminal"
+" and run the above command again to update the installed packages."
+msgstr ""
+"MSYS2および``pacman``を先に更新する必要があるかもしれません．"
+"その場合，端末を再起動し，上記のコマンドを再度実行して，"
+"インストールされたパッケージを更新します．"
+
+#: ../../pages/how-to/installation.md:60
+msgid ""
+"If you are using the *MinGW64 terminal* you can install the required "
+"software with"
+msgstr ""
+"*MinGW64 terminal*を利用しているのであれば，必要なソフトウェアを"
+"次のコマンドでインストールできます．"
+
+#: ../../pages/how-to/installation.md:67
+msgid ""
+"Both *git* and *gfortran* are not mandatory dependencies for running fpm."
+" If you provide *git* and *gfortran* from outside they will get picked up"
+" as well."
+msgstr ""
+"*git*と*gfortran*は，どちらもfpmを実行するために必要な依存ソフトウェアではありません．"
+"*git*と*gfortran*を外部から導入した場合，それらも見つけられます．"
+
+#: ../../pages/how-to/installation.md:72
+msgid "{fab}`apple` Homebrew package manager"
+msgstr "{fab}`apple` Homebrewパッケージ管理システムの利用"
+
+#: ../../pages/how-to/installation.md:74
+msgid ""
+"The Fortran Package Manager (fpm) is available for the "
+"[homebrew](https://brew.sh) package manager on MacOS via an additional "
+"tap. To install fpm via brew, include the new tap and install it using"
+msgstr ""
+"Fortranパッケージマネージャ（fpm）は，MacOSの[homebrew](https://brew.sh)"
+"パッケージマネージャから，追加のtapとして利用できるようになりました．"
+"brewからfpmをインストールするには，新しいtapをインクルードし，"
+"以下のコマンドを用いてインストールします．"
+
+#: ../../pages/how-to/installation.md:82
+msgid ""
+"Binary distributions are available for MacOS 11 (Catalina) and 12 (Big "
+"Sur) for x86\\_64 architectures. For other platforms fpm will be built "
+"locally from source automatically."
+msgstr ""
+"x86\\_64アーキテクチャのMacOS 11 (Catalina)と12 (Big Sur)では"
+"バイナリが利用できます．他のプラットフォームでは，"
+"fpmは自動的にソースからビルドされます．"
+
+#: ../../pages/how-to/installation.md:85
+msgid "Fpm should be available and functional after those steps."
+msgstr "これらの手順を実行すると，fpmは利用可能になります．"
+
+#: ../../pages/how-to/installation.md:88
+msgid "{fab}`apple` {fab}`linux` Conda package manager"
+msgstr "{fab}`apple` {fab}`linux` Condaパッケージ管理システムの利用"
+
+#: ../../pages/how-to/installation.md:90
+msgid ""
+"Fpm is available on [conda-forge], to add conda-forge to your channels "
+"use:"
+msgstr ""
+"Fpmは[conda-forge]で公開されています．"
+"conda-forgeをチャンネルに追加するには，次のコマンドを使用します．"
+
+#: ../../pages/how-to/installation.md:96
+msgid "Fpm can be installed with:"
+msgstr "Fpmは，以下のコマンドによってインストールされます．"
+
+#: ../../pages/how-to/installation.md:103
+msgid ""
+"Alternatively, if you want fpm to be always available directly install "
+"into your current environment with"
+msgstr ""
+"あるいは，fpmを常に利用できるようにしたい場合，次のコマンドを用いて"
+"現在の環境に直接インストールします．"
+
+#: ../../pages/how-to/installation.md:110
+msgid ""
+"The conda package manager can be installed from "
+"[miniforge](https://github.com/conda-forge/miniforge/releases) or from "
+"[miniconda](https://docs.conda.io/en/latest/miniconda.html)."
+msgstr ""
+"condaパッケージ管理システムは，"
+"[miniforge](https://github.com/conda-forge/miniforge/releases)もしくは"
+"[miniforge](https://github.com/conda-forge/miniforge/releases)から"
+"インストールできます．"
+
+#: ../../pages/how-to/installation.md:118
+msgid "{fab}`linux` Arch Linux user repository"
+msgstr "{fab}`linux` Arch Linuxユーザリポジトリの利用"
+
+#: ../../pages/how-to/installation.md:120
+msgid ""
+"The Arch Linux user repository (AUR) contains two packages for the "
+"Fortran Package Manager (fpm). With the [fortran-fpm-"
+"bin](https://aur.archlinux.org/packages/fortran-fpm-bin/) installs the "
+"statically linked Linux/x86\\_64 binary from the release page, while the "
+"[fortran-fpm](https://aur.archlinux.org/packages/fortran-fpm/) package "
+"will bootstrap fpm from source."
+msgstr ""
+"Arch Linuxユーザリポジトリ（AUR）には，Fortranパッケージマネージャ（fpm）"
+"のパッケージが二つ存在しています．"
+" [fortran-fpm-bin](https://aur.archlinux.org/packages/fortran-fpm-bin/)"
+"は，静的にリンクされたLinux/x86\\_64バイナリをリリースページからインストールし，"
+"他方の[fortran-fpm](https://aur.archlinux.org/packages/fortran-fpm/)は"
+"fpmをソースから自己的に構築します．"
+
+#: ../../pages/how-to/installation.md:123
+msgid "Select one of the PKGBUILDs and retrieve it with"
+msgstr "一つのPKGBUILDを選び，次のコマンドで取得します．"
+
+#: ../../pages/how-to/installation.md:130
+msgid ""
+"As usual, first inspect the PKGBUILD before building it. After verifying "
+"the PKGBUILD is fine, build the package with"
+msgstr ""
+"通常，選択したPKGBUILDをビルドする前に，検査を行います．"
+"PKGBUILDが正常であると確認した後，次のコマンドでパッケージをビルドします．"
+
+#: ../../pages/how-to/installation.md:137
+msgid "Once the build passed pacman will ask to install the fpm package."
+msgstr "ビルドが成功すると，pacmanはfpmパッケージをインストールするかを確認してきます．"
+
+#: ../../pages/how-to/installation.md:140
+msgid "Building from source"
+msgstr "ソースからのビルド"
+
+#: ../../pages/how-to/installation.md:142
+msgid ""
+"To build fpm from source get the latest fpm source, either by cloning the"
+" repository from GitHub with"
+msgstr ""
+"fpmをソースからビルドするには，以下のコマンドでGitHubリポジトリをクローンし，最新のfpmのソースを入手します．"
+
+#: ../../pages/how-to/installation.md:149
+msgid "or by downloading a source tarball from the latest source"
+msgstr "もしくは，最新ソースのtarballをダウンロードします．"
+
+#: ../../pages/how-to/installation.md:157
+msgid ""
+"The available install script allows to bootstrap fpm by using just a "
+"Fortran compiler, git and network access. Invoke the script to start the "
+"bootstrap build"
+msgstr ""
+"利用可能なインストールスクリプトを用いると，Fortranコンパイラ，git，"
+"ネットワークアクセスのみでfpmを自己的に構築できます．"
+"自己構築を開始するために，次のようにスクリプトを実行します．"
+
+#: ../../pages/how-to/installation.md:164
+msgid "Fpm will be installed in ``~/.local/bin/fpm``."
+msgstr "Fpmは``~/.local/bin/fpm``にインストールされます．"
+
+#: ../../pages/how-to/installation.md:167
+msgid ""
+"Building the bootstrapper binary from the single source file version "
+"might take a few seconds, which might make the install script look like "
+"it is hanging."
+msgstr ""
+"単一版のソースファイルから自己構築用バイナリをビルドすると，数秒かかる場合があるため，"
+"インストールスクリプトが停止しているようにみえるかもしれません．"
+
+#: ../../pages/how-to/installation.md:171
+msgid ""
+"The installation location can be adjusted by passing the "
+"``--prefix=/path/to/install`` option."
+msgstr ""
+"インストール場所は``--prefix=/path/to/install``オプションを"
+"渡すことで変更できます．"
+
+#: ../../pages/how-to/installation.md:174
+msgid ""
+"If you can't run the install script, you can perform the bootstrap "
+"procedure manually, with the following three steps:"
+msgstr ""
+"インストールスクリプトが実行されない場合は，以下の三手順で"
+"自己構築を手動実行します．"
+
+#: ../../pages/how-to/installation.md:176
+msgid "Download the single source version of fpm"
+msgstr "fpmの単一版ソースをダウンロードします．"
+
+#: ../../pages/how-to/installation.md:182
+msgid "Build a bootstrap binary from the single source version"
+msgstr "単一版ソースから自己構築用バイナリをビルドします．"
+
+#: ../../pages/how-to/installation.md:189
+msgid "Use the bootstrap binary to build the feature complete fpm version"
+msgstr "自己構築用バイナリを使用し，完全版のfpmをビルドします．"

--- a/locale/ja/LC_MESSAGES/index.po
+++ b/locale/ja/LC_MESSAGES/index.po
@@ -1,0 +1,155 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 Fortran programming language community
+# This file is distributed under the same license as the fpm package.
+# Tomohiro Degawa <degawa.tomohiro@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: fpm \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-20 15:35+0900\n"
+"PO-Revision-Date: 2022-03-20 20:58+0900\n"
+"Last-Translator: 出川智啓 <degawa.tomohiro@gmail.com>\n"
+"Language-Team: degawa <https://github.com/degawa>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../pages/index.md:141
+msgid "Tutorial"
+msgstr "実践手引"
+
+#: ../../pages/index.md:141
+msgid "How-To"
+msgstr "利用方法"
+
+#: ../../pages/index.md:141
+msgid "Design"
+msgstr "設計文書"
+
+#: ../../pages/index.md:141
+msgid "Reference"
+msgstr "参考資料"
+
+#: ../../pages/index.md:141
+msgid "Registry"
+msgstr "レジストリ"
+
+#: ../../pages/index.md:5 ../../pages/index.md:13
+msgid "Fortran Package Manager"
+msgstr "Fortranパッケージマネージャ"
+
+#: ../../pages/index.md:16
+msgid "Package manager and build system for Fortran"
+msgstr "Fortranのパッケージ管理およびビルドシステム"
+
+#: ../../pages/index.md:19
+msgid "Welcome to the documentation for the Fortran Package Manager (fpm)."
+msgstr "Fortarnパッケージマネージャ（fpm）の解説へようこそ．"
+
+#: ../../pages/index.md:21
+msgid ""
+"This documentation is divided into four parts. Select one of the topics "
+"below to continue."
+msgstr ""
+"この資料集は，下記の四つの内容から構成されています．"
+"読み進めるには，いずれか一つを選択してください．"
+
+#: ../../pages/index.md:25
+msgid ""
+"These pages are currently under construction. Please help us improve them"
+" by contributing content or reporting issues."
+msgstr ""
+"これらの解説は現在執筆中です．"
+"内容の提供，問題の報告など，改善にご協力をお願いします．"
+
+#: ../../pages/index.md:39
+msgid "{octicon}`mortar-board` Tutorials"
+msgstr "{octicon}`mortar-board` 実践手引"
+
+#: ../../pages/index.md:42
+msgid ""
+"Learn about using fpm for Fortran development, creating projects and "
+"managing dependencies."
+msgstr ""
+"fpmを用いたFortran開発，プロジェクト作成，依存関係管理の学習"
+
+#: ../../pages/index.md:45
+msgid "Browse tutorials"
+msgstr ""
+# "Browse tutorials" buttom is not working when msgstr is set
+
+#: ../../pages/index.md:61
+msgid "{octicon}`book` How-To Guides"
+msgstr "{octicon}`book` 利用方法"
+
+#: ../../pages/index.md:64
+msgid "Practical guides and recipes to solve specific problems with fpm"
+msgstr "fpmを用いて具体的な問題を解決するための実践的な利用方法と秘訣"
+
+#: ../../pages/index.md:67
+msgid "Browse recipes"
+msgstr ""
+# "Browse recipes" buttom is not working when msgstr is set
+
+#: ../../pages/index.md:83
+msgid "{octicon}`milestone` Design Documents"
+msgstr "{octicon}`milestone` 設計文書"
+
+#: ../../pages/index.md:86
+msgid ""
+"Resources about the design of the command line interface, the package "
+"manifest, and the general user experience"
+msgstr ""
+"コマンドラインインタフェース，パッケージマニフェスト，一般的な使用感の設計に関する情報"
+
+#: ../../pages/index.md:89
+msgid "Browse documents"
+msgstr ""
+# "Browse documents" buttom is not working when msgstr is set
+
+#: ../../pages/index.md:105
+msgid "{octicon}`gear` References"
+msgstr "{octicon}`gear` 参考資料"
+
+#: ../../pages/index.md:108
+msgid "Specifications of fpm components and implementation references"
+msgstr "fpmの仕様と実装情報"
+
+#: ../../pages/index.md:111
+msgid "Browse references"
+msgstr ""
+# "Browse references" buttom is not working when msgstr is set
+
+#: ../../pages/index.md:123
+msgid "{fa}`cubes` Registry"
+msgstr "{fa}`cubes` レジストリ"
+
+#: ../../pages/index.md:125
+msgid ""
+"There are already many packages available for use with fpm, providing an "
+"easily accessible and rich ecosystem of general purpose and high-"
+"performance code. For a full list of packages checkout the [fpm "
+"registry](https://fortran-lang.org/packages/fpm). New packages can be "
+"submitted to the registry [here](https://github.com/fortran-lang/fpm-"
+"registry)."
+msgstr ""
+"fpmで利用できるパッケージは既に多数あり，汎用的で高性能なコードを容易に入手できる，"
+"豊かなエコシステムが提供されています．"
+"[fpm registry](https://fortran-lang.org/packages/fpm)で全てのパッケージを確認できます．"
+"新しいパッケージを登録するには，[こちら](https://github.com/fortran-lang/fpm-registry)から"
+"申請してください．"
+
+#: ../../pages/index.md:130
+msgid "{fa}`newspaper` News"
+msgstr "{fa}`newspaper` 新着情報"
+
+#: ../../pages/index.md:132
+msgid ""
+"Recent events around the Fortran Package Manager, such as new releases, "
+"conference talks, and new packages will be announced here."
+msgstr ""
+"ここでは，新規リリース，学会発表，新しいパッケージなど，"
+"Fortranパッケージマネージャに関する最近の出来事を告知します．"

--- a/locale/ja/LC_MESSAGES/news.po
+++ b/locale/ja/LC_MESSAGES/news.po
@@ -1,0 +1,216 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 Fortran programming language community
+# This file is distributed under the same license as the fpm package.
+# Tomohiro Degawa <degawa.tomohiro@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: fpm \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-20 15:35+0900\n"
+"PO-Revision-Date: 2022-03-22 20:58+0900\n"
+"Last-Translator: 出川智啓 <degawa.tomohiro@gmail.com>\n"
+"Language-Team: degawa <https://github.com/degawa>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../pages/news.md:3
+msgid "News"
+msgstr "新着情報"
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:7
+msgid "Fpm version 0.5.0 released"
+msgstr "Fpm 0.5.0をリリースしました"
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:9
+msgid ""
+"We have a large number of bug fixes in this release and made plenty of "
+"improvements to the tooling around fpm, like the continuous delivery and "
+"the Windows installer. New features include the possibility for better "
+"compiler/linker selection and the improved build backend (test are only "
+"build when needed, link dependencies are properly tracked)."
+msgstr ""
+"このリリースには，多くのバグ修正があり，また継続的デリバリやWindowsインストーラといった"
+"fpmの周辺ツールに多くの改善が加えられています．"
+"新機能として，コンパイラ・リンカの選択の幅が広がり，バックエンドが改善されました．"
+"（テストは必要な場合にのみビルドされ，リンクの依存関係は適切に追跡されます）"
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:12
+msgid ""
+"Find the full release notes [here](https://github.com/fortran-"
+"lang/fpm/releases/tag/v0.5.0)."
+msgstr ""
+"リリースノートの全文は[こちら](https://github.com/fortran-"
+"lang/fpm/releases/tag/v0.5.0)をご覧ください．"
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:14
+msgid "Changes"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:16
+msgid ""
+"tests are only build for fpm test and not by default anymore "
+"([#572](https://github.com/fortran-lang/fpm/pull/572))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:17
+msgid ""
+"environment variables for setting Fortran and C compiler changed "
+"([#549](https://github.com/fortran-lang/fpm/pull/549), "
+"[#584](https://github.com/fortran-lang/fpm/pull/584))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:18
+msgid ""
+"add LFortran optimization flag to release profile "
+"([#597](https://github.com/fortran-lang/fpm/pull/597))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:21
+msgid "New features"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:23
+msgid ""
+"command line arguments for linker, archiver and C-compiler added "
+"([#549](https://github.com/fortran-lang/fpm/pull/549))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:26
+msgid "Fixes"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:28
+msgid ""
+"tabs are correctly expanded in source file scanning "
+"([#521](https://github.com/fortran-lang/fpm/pull/521))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:29
+msgid ""
+"installer script will use fpm update to avoid stale dependencies "
+"([#557](https://github.com/fortran-lang/fpm/pull/557))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:30
+msgid ""
+"use multiple build output directories depending on link line options "
+"([#575](https://github.com/fortran-lang/fpm/pull/575))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:31
+msgid ""
+"update truncated help text ([#578](https://github.com/fortran-"
+"lang/fpm/pull/578))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:32
+msgid ""
+"fix directory removal in fpm new tests ([#579](https://github.com"
+"/fortran-lang/fpm/pull/579))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:33
+msgid ""
+"use MSVS like commands for Intel compilers on Windows "
+"([#590](https://github.com/fortran-lang/fpm/pull/590))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:34
+msgid ""
+"add critical section to mkdir in backend ([#613](https://github.com"
+"/fortran-lang/fpm/pull/613))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:35
+msgid ""
+"fix modules listing (for install) ([#612](https://github.com/fortran-"
+"lang/fpm/pull/612))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:36
+msgid ""
+"repair --list option and correct obsolete descriptions of the --list "
+"option ([#607](https://github.com/fortran-lang/fpm/pull/607))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:37
+msgid ""
+"fix incorrect Intel release flag on Windows ([#602](https://github.com"
+"/fortran-lang/fpm/pull/602))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:39
+msgid ""
+"list names without suffix for Windows ([#595](https://github.com/fortran-"
+"lang/fpm/pull/595))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:43
+msgid "Repository updates"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:45
+msgid ""
+"add files and workflow to make installer on release "
+"([#616](https://github.com/fortran-lang/fpm/pull/616))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:46
+msgid ""
+"issue templates added to guide reporting of bugs, package issues, feature"
+" requests and specification proposals ([#558](https://github.com/fortran-"
+"lang/fpm/pull/558))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:47
+msgid ""
+"default branch renamed to *main* ([#565](https://github.com/fortran-"
+"lang/fpm/pull/565))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:48
+msgid ""
+"update documentation on distributions supporting fpm, like spack and "
+"MSYS2 ([#562](https://github.com/fortran-lang/fpm/pull/562))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:49
+msgid ""
+"new workflow to automatically generate single source fpm versions "
+"([#563](https://github.com/fortran-lang/fpm/pull/563))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:50
+msgid ""
+"continuous delivery of current fpm git source implemented "
+"([#569](https://github.com/fortran-lang/fpm/pull/569), "
+"[#564](https://github.com/fortran-lang/fpm/pull/564))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:51
+msgid ""
+"update of bootstrapping instructions ([#587](https://github.com/fortran-"
+"lang/fpm/pull/587))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:52
+msgid ""
+"update README.md compiler, archiver, & link flags "
+"([#598](https://github.com/fortran-lang/fpm/pull/598))"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:55
+msgid "Feedback"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:57
+msgid "[Discourse thread](https://fortran-lang.discourse.group/t/2314)"
+msgstr ""
+
+#: ../../pages/news/2021/11-21-fpm-version-0.5.0.md:58
+msgid "[Twitter post](https://twitter.com/fortranlang/status/1462506491752161286)"
+msgstr ""

--- a/locale/ja/LC_MESSAGES/spec.po
+++ b/locale/ja/LC_MESSAGES/spec.po
@@ -1,0 +1,768 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 Fortran programming language community
+# This file is distributed under the same license as the fpm package.
+# Tomohiro Degawa <degawa.tomohiro@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: fpm \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-20 15:35+0900\n"
+"PO-Revision-Date: 2022-03-22 20:59+0900\n"
+"Last-Translator: 出川智啓 <degawa.tomohiro@gmail.com>\n"
+"Language-Team: degawa <https://github.com/degawa>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../pages/spec/index.md:13
+msgid "API documentation"
+msgstr "API文書"
+
+#: ../../pages/spec/index.md:3
+msgid "Specifications and Reference"
+msgstr "参考資料"
+
+#: ../../pages/spec/index.md:6
+msgid ""
+"This section contains the specifications the components of the Fortran "
+"Package Manager."
+msgstr ""
+"ここには，Fortranパッケージマネージャの仕様を掲載しています．"
+
+#: ../../pages/spec/index.md:10
+msgid ""
+"The generated API documentation of the fpm internals can be found "
+"[here](https://fortran-lang.github.io/fpm)."
+msgstr ""
+"fpm内部から生成されたAPI文書は[こちら](https://fortran-lang.github.io/fpm)"
+"から参照できます．"
+
+#: ../../pages/spec/manifest.md:1
+msgid "Manifest reference"
+msgstr "マニフェスト詳説"
+
+#: ../../pages/spec/manifest.md:3
+msgid ""
+"The ``fpm.toml`` file for each project is called its *manifest*. It is "
+"written using the [TOML] format. Every manifest file consists of the "
+"following sections:"
+msgstr ""
+"各プロジェクトの``fpm.toml``ファイルは，マニフェストとよばれています．"
+"これは[TOML](https://toml.io/ja/)形式で記述されます．"
+"マニフェストファイルは，以下の設定項目で構成されます．"
+
+#: ../../pages/spec/manifest.md:7
+msgid "[*name*](#project-name): The name of the project"
+msgstr "[*name*](#project-name): プロジェクトの名前"
+
+#: ../../pages/spec/manifest.md:9
+msgid "[*version*](#project-version): The version of the project"
+msgstr "[*version*](#project-version): プロジェクトのバージョン"
+
+#: ../../pages/spec/manifest.md:11
+msgid "[*license*](#project-license): The project license"
+msgstr "[*license*](#project-license): プロジェクトのライセンス"
+
+#: ../../pages/spec/manifest.md:13
+msgid "[*maintainer*](#project-maintainer): Maintainer of the project"
+msgstr "[*maintainer*](#project-maintainer): プロジェクトのメンテナ"
+
+#: ../../pages/spec/manifest.md:15
+msgid "[*author*](#project-author): Author of the project"
+msgstr "[*author*](#project-author): プロジェクトの作成者"
+
+#: ../../pages/spec/manifest.md:17
+msgid "[*copyright*](#project-copyright): Copyright of the project"
+msgstr "[*copyright*](#project-copyright): プロジェクトの著作権"
+
+#: ../../pages/spec/manifest.md:19
+msgid "[*description*](#project-description): Description of the project"
+msgstr "[*description*](#project-description): プロジェクトの概要"
+
+#: ../../pages/spec/manifest.md:21
+msgid ""
+"[*categories*](#project-categories): Categories associated with the "
+"project"
+msgstr ""
+"[*categories*](#project-categories): プロジェクトに関連する分類"
+
+#: ../../pages/spec/manifest.md:23
+msgid "[*keywords*](#project-keywords): Keywords describing the project"
+msgstr "[*keywords*](#project-keywords): プロジェクトを説明するキーワード"
+
+#: ../../pages/spec/manifest.md:25
+msgid "[*homepage*](#project-homepage): The project's homepage"
+msgstr "[*homepage*](#project-homepage): プロジェクトのホームページ"
+
+#: ../../pages/spec/manifest.md:27
+msgid "Build configuration:"
+msgstr "ビルド設定:"
+
+#: ../../pages/spec/manifest.md:28
+msgid ""
+"[*auto-tests*](#automatic-target-discovery): Toggle automatic discovery "
+"of test executables"
+msgstr ""
+"[*auto-tests*](#automatic-target-discovery): テスト用実行ファイルの自動検出の切替"
+
+#: ../../pages/spec/manifest.md:30
+msgid ""
+"[*auto-examples*](#automatic-target-discovery): Toggle automatic "
+"discovery of example programs"
+msgstr ""
+"[*auto-examples*](#automatic-target-discovery): サンプルプログラムの自動検出の切替"
+
+#: ../../pages/spec/manifest.md:32
+msgid ""
+"[*auto-executables*](#automatic-target-discovery): Toggle automatic "
+"discovery of executables"
+msgstr ""
+"[*auto-executables*](#automatic-target-discovery): 実行ファイルの自動検出の切替"
+
+#: ../../pages/spec/manifest.md:34
+msgid "[*link*](#link-external-libraries): Link with external dependencies"
+msgstr "[*link*](#link-external-libraries): 外部依存関係とのリンク"
+
+#: ../../pages/spec/manifest.md:36
+msgid ""
+"[*external-modules*](#use-system-installed-modules): Specify modules used"
+" that are not within your fpm package"
+msgstr ""
+"[*external-modules*](#use-system-installed-modules): fpmパッケージ内に存在しないモジュールの指定"
+
+#: ../../pages/spec/manifest.md:38
+msgid "Target sections:"
+msgstr "構築対象に関する設定項目"
+
+#: ../../pages/spec/manifest.md:39
+msgid "[*library*](#library-configuration) Configuration of the library target"
+msgstr "[*library*](#library-configuration) ビルドされるライブラリの設定"
+
+#: ../../pages/spec/manifest.md:41
+msgid ""
+"[*executable*](#executable-targets) Configuration of the executable "
+"targets"
+msgstr ""
+"[*executable*](#executable-targets) ビルドされる実行ファイルの設定"
+
+#: ../../pages/spec/manifest.md:43
+msgid "[*test*](#test-targets) Configuration of the test targets"
+msgstr "[*test*](#test-targets) ビルドされるテストの設定"
+
+#: ../../pages/spec/manifest.md:45
+msgid "Dependency sections:"
+msgstr "依存関係に関する設定項目"
+
+#: ../../pages/spec/manifest.md:46
+msgid "[*dependencies*](#specifying-dependencies): Project library dependencies"
+msgstr "[*dependencies*](#specifying-dependencies): プロジェクトが参照するライブラリの依存関係"
+
+#: ../../pages/spec/manifest.md:48
+msgid ""
+"[*dev-dependencies*](#development-dependencies): Dependencies only needed"
+" for tests"
+msgstr ""
+"[*dev-dependencies*](#development-dependencies): テストのみに必要な依存関係"
+
+#: ../../pages/spec/manifest.md:50
+msgid "[*install*](#installation-configuration): Installation configuration"
+msgstr "[*install*](#installation-configuration): インストール設定"
+
+#: ../../pages/spec/manifest.md:52
+msgid "[*extra*](#additional-free-data-field): Additional free data field"
+msgstr "[*extra*](#additional-free-data-field): 設定の追加欄"
+
+#: ../../pages/spec/manifest.md:59
+msgid "Project name"
+msgstr "プロジェクトの名前"
+
+#: ../../pages/spec/manifest.md:61
+msgid ""
+"The project name identifies the package and is used to refer to it. It is"
+" used when listing the project as dependency for another package and the "
+"default name of the library and executable target. Therefore, the project"
+" name must always be present."
+msgstr ""
+"プロジェクト名は，パッケージを識別し，それを参照するために用いられます．"
+"ライブラリと実行ファイルの標準の名前として用いられ，また他のパッケージの"
+"依存関係としてプロジェクトを列挙するときにも用いられます．"
+"したがって，プロジェクト名は常に記述する必要があります．"
+
+#: ../../pages/spec/manifest.md:65 ../../pages/spec/manifest.md:77
+#: ../../pages/spec/manifest.md:85 ../../pages/spec/manifest.md:120
+#: ../../pages/spec/manifest.md:131 ../../pages/spec/manifest.md:142
+#: ../../pages/spec/manifest.md:154 ../../pages/spec/manifest.md:165
+#: ../../pages/spec/manifest.md:176 ../../pages/spec/manifest.md:187
+#: ../../pages/spec/manifest.md:207 ../../pages/spec/manifest.md:225
+#: ../../pages/spec/manifest.md:256 ../../pages/spec/manifest.md:300
+#: ../../pages/spec/manifest.md:336 ../../pages/spec/manifest.md:363
+#: ../../pages/spec/manifest.md:391 ../../pages/spec/manifest.md:400
+msgid "*Example:*"
+msgstr "**例:**"
+
+#: ../../pages/spec/manifest.md:72
+msgid "Project version"
+msgstr "プロジェクトのバージョン"
+
+#: ../../pages/spec/manifest.md:74
+msgid ""
+"The version number of the project is specified as string. A standardized "
+"way to manage and specify versions is the [Semantic Versioning] scheme."
+msgstr ""
+"プロジェクトのバージョン番号を文字列で指定します．"
+"バージョンを管理・指定する標準的な方法は，"
+"[セマンティックバージョニング](https://semver.org/lang/ja/)です．"
+
+#: ../../pages/spec/manifest.md:83
+msgid ""
+"The version entry can also contain a filename relative to the project "
+"root, which contains the version number of the project"
+msgstr ""
+"versionの設定値として，プロジェクトのバージョン番号を含むファイルの名前を"
+"プロジェクト直下からの相対パスで指定できます．"
+
+#: ../../pages/spec/manifest.md:94
+msgid "Project license"
+msgstr "プロジェクトのライセンス"
+
+#: ../../pages/spec/manifest.md:96
+msgid ""
+"The project license field contains the license identifier. A standardized"
+" way to specify licensing information are [SPDX] identifiers."
+msgstr ""
+"プロジェクトのライセンス設定欄には，ライセンス識別子を記述します．"
+"ライセンス情報を指定する標準的な方法は，[SPDX](https://spdx.org/licenses/)識別子です．"
+
+#: ../../pages/spec/manifest.md:99
+msgid "*Examples:*"
+msgstr "**例:**"
+
+#: ../../pages/spec/manifest.md:101
+msgid ""
+"Projects licensed under the [GNU Lesser General Public "
+"License](https://www.gnu.org/licenses/lgpl-3.0-standalone.html), either "
+"version 3 or any later version, is specified as"
+msgstr ""
+"[GNU Lesser General Public License]のバージョン3もしくはそれ以降"
+"(https://www.gnu.org/licenses/lgpl-3.0-standalone.html)"
+"の下で許諾されるプロジェクトは，次のように指定します．"
+
+#: ../../pages/spec/manifest.md:107
+msgid ""
+"Dual licensed project under the [Apache license, version "
+"2.0](http://www.apache.org/licenses/LICENSE-2.0) or the [MIT "
+"license](https://opensource.org/licenses/MIT) are specified as"
+msgstr ""
+" [Apache license, version 2.0](http://www.apache.org/licenses/LICENSE-2.0)"
+"もしくは[MIT license](https://opensource.org/licenses/MIT)の"
+"デュアルライセンスのプロジェクトの場合は，次のように指定します．"
+
+#: ../../pages/spec/manifest.md:116
+msgid "Project maintainer"
+msgstr "プロジェクトのメンテナ"
+
+#: ../../pages/spec/manifest.md:118
+msgid "Information on the project maintainer and means to reach out to them."
+msgstr "プロジェクトのメンテナに関する情報および連絡手段を記載します．"
+
+#: ../../pages/spec/manifest.md:127
+msgid "Project author"
+msgstr "プロジェクトの作成者"
+
+#: ../../pages/spec/manifest.md:129
+msgid "Information on the project author."
+msgstr "プロジェクト作成者の情報を記載します．"
+
+#: ../../pages/spec/manifest.md:138
+msgid "Project copyright"
+msgstr "プロジェクトの著作権"
+
+#: ../../pages/spec/manifest.md:140
+msgid "A statement clarifying the copyright status of the project."
+msgstr "プロジェクトの著作権を明示する文言を記述します．"
+
+#: ../../pages/spec/manifest.md:149
+msgid "Project description"
+msgstr "プロジェクトの概要"
+
+#: ../../pages/spec/manifest.md:151
+msgid ""
+"The description provides a short summary on the project. It should be "
+"plain text and not using any markup formatting."
+msgstr ""
+"プロジェクトに関する要約を記述します．"
+"プレーンテキストを用いてください．装飾用の情報は挿入しないでください．"
+
+#: ../../pages/spec/manifest.md:161
+msgid "Project categories"
+msgstr "プロジェクトの分類"
+
+#: ../../pages/spec/manifest.md:163
+msgid "The project can be associated with different categories."
+msgstr "プロジェクトは，様々な分類と関連付けることができます．"
+
+#: ../../pages/spec/manifest.md:172
+msgid "Project keywords"
+msgstr "プロジェクトのキーワード"
+
+#: ../../pages/spec/manifest.md:174
+msgid "The keywords field is an array of strings describing the project."
+msgstr "プロジェクトを説明する文字の配列を記述します．"
+
+#: ../../pages/spec/manifest.md:183
+msgid "Project homepage"
+msgstr "プロジェクトのホームページ"
+
+#: ../../pages/spec/manifest.md:185
+msgid "URL to the webpage of the project."
+msgstr "プロジェクトのウェブページへのURLを記載します．"
+
+#: ../../pages/spec/manifest.md:194
+msgid "Project targets"
+msgstr "プロジェクトの構築対象"
+
+#: ../../pages/spec/manifest.md:196
+msgid ""
+"Every fpm project can define library, executable and test targets. "
+"Library targets are exported and useable for other projects."
+msgstr ""
+"すべてのfpmプロジェクトは，構築対象としてライブラリ，実行ファイル，テストを定義できます．"
+"構築されたライブラリは，他のプロジェクトで利用できます．"
+
+#: ../../pages/spec/manifest.md:200
+msgid "Library configuration"
+msgstr "ライブラリ"
+
+#: ../../pages/spec/manifest.md:202
+msgid ""
+"Defines the exported library target of the project. A library is "
+"generated if the source directory or include directory is found in a "
+"project. The default source and include directories are ``src`` and "
+"``include``; these can be modified in the *library* section using the "
+"*source-dir* and *include-dir* entries. Paths for the source and include "
+"directories are given relative to the project root and use ``/`` as path "
+"separator on all platforms."
+msgstr ""
+"プロジェクト内で構築され，展開されるライブラリを定義します．"
+"プロジェクト内にソースディレクトリもしくはインクルードディレクトリが見つかれば，"
+"ライブラリが生成されます．ソースおよびインクルードディレクトリの標準の名前は"
+"それぞれ ``src``および``include``であり，*library*設定項目の*source-dir*および"
+"*include-dir*で変更できます．ソースおよびインクルードディレクトリのパスは"
+"プロジェクト直下からの相対パスで与え，パスの区切りには``/``を用います．"
+
+#: ../../pages/spec/manifest.md:215
+msgid "Include directory"
+msgstr "インクルードディレクトリ"
+
+#: ../../pages/spec/manifest.md:218 ../../pages/spec/manifest.md:355
+#: ../../pages/spec/manifest.md:410
+msgid "Supported in Fortran fpm only"
+msgstr "Fortran fpmのみ対応しています．"
+
+#: ../../pages/spec/manifest.md:221
+msgid ""
+"Projects which use the Fortran `include` statement or C preprocessor "
+"`#include` statement, can use the *include-dir* key to specify search "
+"directories for the included files. *include-dir* can contain one or more"
+" directories, where multiple directories are specified using a list of "
+"strings. Include directories from all project dependencies are passed to "
+"the compiler using the appropriate compiler flag."
+msgstr ""
+"Fortranの`include`文やCプリプロセッサの`#include`文を使用するプロジェクトでは，"
+"*include-dir*をインクルードファイルの探索ディレクトリの指定に利用できます．"
+"*include-dir*は一つ以上のディレクトリを指定でき，"
+"複数のディレクトリを指定するには文字列のリストを用います．"
+"依存関係で指定される全てのインクルードディレクトリは，適切なコンパイラフラグ"
+"を介してコンパイラに渡されます．"
+
+#: ../../pages/spec/manifest.md:233
+msgid "*include-dir* does not currently allow using pre-built module `.mod` files"
+msgstr "現在の所，*include-dir*はビルド済みモジュールである`.mod`ファイルを使用できません．"
+
+#: ../../pages/spec/manifest.md:237
+msgid "Executable targets"
+msgstr "実行ファイル"
+
+#: ../../pages/spec/manifest.md:239
+msgid ""
+"Executable targets are Fortran programs defined as *executable* sections."
+" If no executable section is specified the ``app`` directory is searched "
+"for program definitions. For explicitly specified executables the *name* "
+"entry must always be specified. The source directory for each executable "
+"can be adjusted in the *source-dir* entry. Paths for the source directory"
+" are given relative to the project root and use ``/`` as path separator "
+"on all platforms. The source file containing the program body can be "
+"specified in the *main* entry."
+msgstr ""
+"実行ファイルは，*executable*設定項目で指定されたFortranのプログラムです．"
+"もし*executable*が書かれていない場合，``app``ディレクトリで"
+"``program``の定義が探索されます．明示的に実行ファイルを設定する場合，*name*"
+"が指定されている必要があります．各実行ファイルのソースディレクトリは，*source-dir*"
+"で設定できます．ソースディレクトリへのパスは，プロジェクト直下からの相対パスで与え，"
+"パスの区切りには``/``を用います．メインルーチンが定義されているソースファイルの名前は，"
+"*main*で指定します．"
+
+#: ../../pages/spec/manifest.md:246
+msgid ""
+"Executables can have their own dependencies. See [specifying dependencies"
+"](#specifying-dependencies) for more details."
+msgstr ""
+"複数の実行ファイルがある場合，実行ファイルごとに依存関係を持つことができます．"
+"[依存関係の指定](#specifying-dependencies)を参照してください．"
+
+#: ../../pages/spec/manifest.md:249
+msgid ""
+"Executables can also specify their own external library dependencies. See"
+" [external libraries](#link-external-libraries) for more details."
+msgstr ""
+"複数の実行ファイルがある場合，実行ファイルごとに外部ライブラリを指定できます．"
+"[外部ライブラリのリンク](#link-external-libraries)を参照してください．"
+
+#: ../../pages/spec/manifest.md:253 ../../pages/spec/manifest.md:297
+#: ../../pages/spec/manifest.md:333
+msgid "Linking against libraries is supported in Fortran fpm only"
+msgstr "ライブラリのリンクは，Fortran fpmのみ対応しています．"
+
+#: ../../pages/spec/manifest.md:271
+msgid ""
+"Specifying many separate executables can be done by using inline tables "
+"for brevity instead"
+msgstr ""
+"インラインテーブルを使用することで，多数の実行ファイルに対する個別の指定を簡潔に記述できます．"
+
+#: ../../pages/spec/manifest.md:281
+msgid "Example targets"
+msgstr "サンプル"
+
+#: ../../pages/spec/manifest.md:283
+msgid ""
+"Example applications for a project are defined as *example* sections. If "
+"no example section is specified the ``example`` directory is searched for"
+" program definitions. For explicitly specified examples the *name* entry "
+"must always be specified. The source directory for each example can be "
+"adjusted in the *source-dir* entry. Paths for the source directory are "
+"given relative to the project root and use ``/`` as path separator on all"
+" platforms. The source file containing the program body can be specified "
+"in the *main* entry."
+msgstr ""
+"プロジェクトのサンプルアプリケーションは，*example*設定項目で定義されます．"
+"もし*example*が指定されていない場合，``example``ディレクトリで"
+"``program``の定義が探索されます．明示的にサンプルを設定する場合，*name*"
+"が指定されている必要があります．各サンプルのソースディレクトリは，*source-dir*"
+"で設定できます．ソースディレクトリへのパスは，プロジェクト直下からの相対パスで与え，"
+"パスの区切りには``/``を用います．プログラム本体を含むソースファイルの名前は，"
+"*main*で指定します．"
+
+#: ../../pages/spec/manifest.md:290
+msgid ""
+"Examples can have their own dependencies. See [specifying dependencies"
+"](#specifying-dependencies) for more details."
+msgstr ""
+"複数のサンプルがある場合，サンプルごとに依存関係を持つことができます．"
+"[依存関係の指定](#specifying-dependencies)を参照してください．"
+
+
+#: ../../pages/spec/manifest.md:293
+msgid ""
+"Examples can also specify their own external library dependencies. See "
+"[external libraries](#link-external-libraries) for more details."
+msgstr ""
+"複数のサンプルがある場合，サンプルごとに外部ライブラリを指定できます．"
+"[外部ライブラリ](#link-external-libraries)を参照してください．"
+
+#: ../../pages/spec/manifest.md:316
+msgid "Test targets"
+msgstr "テスト"
+
+#: ../../pages/spec/manifest.md:318
+msgid ""
+"Test targets are Fortran programs defined as *test* sections. They follow"
+" similar rules as the executable targets. If no test section is specified"
+" the ``test`` directory is searched for program definitions. For "
+"explicitly specified tests the *name* entry must always be specified. The"
+" source directory for each test can be adjusted in the *source-dir* "
+"entry. Paths for the source directory are given relative to the project "
+"root and use ``/`` as path separator on all platforms. The source file "
+"containing the program body can be specified in the *main* entry."
+msgstr ""
+"テストは，*test*設定項目で定義されたFortranプログラムです．これらは"
+"実行ファイルと同様の規則に従います．"
+"もし*test*が指定されていない場合，``test``ディレクトリで"
+"``program``の定義が探索されます．明示的にテストを設定する場合，*name*"
+"が指定されている必要があります．各実行ファイルのソースディレクトリは，*source-dir*"
+"で設定できます．ソースディレクトリへのパスは，プロジェク直下からの相対パスで与え，"
+"パスの区切りには``/``を用います．プログラム本体を含むソースファイルの名前は，"
+"*main*で指定します．"
+
+#: ../../pages/spec/manifest.md:326
+msgid ""
+"Tests can have their own dependencies. See [specifying dependencies"
+"](#specifying-dependencies) for more details."
+msgstr ""
+"複数のテストがある場合，テストごとに依存関係を持つことができます．"
+"[依存関係の指定](#specifying-dependencies)を参照してください．"
+
+
+#: ../../pages/spec/manifest.md:329
+msgid ""
+"Tests can also specify their own external library dependencies. See "
+"[external libraries](#link-external-libraries) for more details."
+msgstr ""
+"複数のテストがある場合，テストごとに外部ライブラリを指定できます．"
+"[外部ライブラリのリンク](#link-external-libraries)を参照してください．"
+
+#: ../../pages/spec/manifest.md:352
+msgid "Link external libraries"
+msgstr "外部ライブラリのリンク"
+
+#: ../../pages/spec/manifest.md:358
+msgid ""
+"To declare link time dependencies on external libraries a list of native "
+"libraries can be specified in the *link* entry. Specify either one "
+"library as string or a list of strings in case several libraries should "
+"be linked. When possible the project should only link one native library."
+" The list of library dependencies is exported to dependent packages."
+msgstr ""
+"外部ライブラリリンク時の依存関係を宣言するために，*link*設定項目に"
+"ネイティブライブラリの一覧を指定できます．一つのライブラリは文字列で指定し，"
+"複数のライブラリをリンクする場合は文字列のリストを用います．"
+"できることなら，プロジェクトは一つのネイティブライブラリのみをリンクするべきでしょう．"
+"依存ライブラリの一覧は，依存するパッケージにも展開されます．"
+
+#: ../../pages/spec/manifest.md:365
+msgid "To link against the zlib compression library use"
+msgstr "zlib圧縮ライブラリをリンクするには，次の設定を用います．"
+
+#: ../../pages/spec/manifest.md:372
+msgid ""
+"To dependent on LAPACK also BLAS should be linked. In this case the order"
+" of the libraries matters:"
+msgstr ""
+"LAPACKに依存する場合，BLASもリンクする必要があります．"
+"この場合，ライブラリの順番に意味があります．"
+
+#: ../../pages/spec/manifest.md:380
+msgid "Use system-installed modules"
+msgstr "システムにインストールされたモジュールの利用"
+
+#: ../../pages/spec/manifest.md:382
+msgid ""
+"To use modules that are not defined within your fpm package or its "
+"dependencies, specify the module name using the *external-modules* key in"
+" the *build* table."
+msgstr ""
+"fpmパッケージやその依存関係の中で定義されていないモジュールを利用するには，"
+"*build*設定項目の*external-modules*を使用して，モジュールの名前を指定します．"
+
+#: ../../pages/spec/manifest.md:386
+msgid ""
+"*fpm* cannot automatically locate external module files; it is the "
+"responsibility of the user to specify the necessary include directories "
+"using compiler flags such that the compiler can locate external module "
+"files during compilation."
+msgstr ""
+"*fpm*は，外部モジュールファイルの位置を自動的に特定できません．"
+"ユーザは，コンパイラがコンパイル時に外部モジュールファイルを発見できるように，"
+"コンパイラフラグを利用してインクルードディレクトリを指定しなければなりません．"
+
+#: ../../pages/spec/manifest.md:398
+msgid "Multiple external modules can be specified as a list."
+msgstr "複数の外部モジュールをリストで指定できます．"
+
+#: ../../pages/spec/manifest.md:407
+msgid "Automatic target discovery"
+msgstr "構築対象の自動検出"
+
+#: ../../pages/spec/manifest.md:413
+msgid ""
+"Executables and test can be discovered automatically in their default "
+"directories. The automatic discovery recursively searches the ``app``, "
+"``example``, and ``test`` directories for ``program`` definitions and "
+"declares them as executable, example, and test targets, respectively. The"
+" automatic discovery is enabled by default."
+msgstr ""
+"実行ファイルとテストは，標準のディレクトリ内であれば自動的に検出されます．"
+"自動検出では，``app``, ``example``, ``test``ディレクトリ内の``program``の定義を"
+"再帰的に検索し，実行ファイル，サンプル，テストをそれぞれ構築対象として宣言します．"
+"自動検出は，標準で有効にされています．"
+
+#: ../../pages/spec/manifest.md:417
+msgid ""
+"To disable the automatic discovery of targets set the *auto-executables*,"
+" *auto-examples*, and *auto-tests* entry to *false*."
+msgstr ""
+"構築対象の自動検出を無効にするには，*auto-executables*,"
+" *auto-examples*, *auto-tests*を*false*に設定します．"
+
+#: ../../pages/spec/manifest.md:427
+msgid "Specifying dependencies"
+msgstr "依存関係の指定"
+
+#: ../../pages/spec/manifest.md:429
+msgid ""
+"Dependencies can be declared in the *dependencies* table in the manifest "
+"root or the [*executable*](#executable-targets) or [*test*](#test-"
+"targets) sections. When declared in the manifest root the dependencies "
+"are exported with the project."
+msgstr ""
+"依存関係は，マニフェスト直下，あるいは[*executable*](#executable-targets)か"
+"[*test*](#test-targets)設定項目に，*dependencies*のテーブルとして宣言できます．"
+"マニフェスト直下に宣言した依存関係は，プロジェクトと共に外部に展開されます．"
+
+#: ../../pages/spec/manifest.md:433
+msgid "Local dependencies"
+msgstr "ローカルな依存関係の指定"
+
+#: ../../pages/spec/manifest.md:435
+msgid "To declare local dependencies use the *path* entry."
+msgstr "ローカルな依存関係を宣言するには，*path*を用います．"
+
+#: ../../pages/spec/manifest.md:442
+msgid ""
+"Local dependency paths are given relative to the project root and use "
+"``/`` as path separator on all platforms."
+msgstr ""
+"ローカルな依存関係のパスは，プロジェクト直下からの相対パスで与え，"
+"パスの区切りには``/``を用います．"
+
+#: ../../pages/spec/manifest.md:445
+msgid "Dependencies from version control systems"
+msgstr "バージョンコントロールシステムからの依存関係の指定"
+
+#: ../../pages/spec/manifest.md:447
+msgid "Dependencies can be specified by the projects git repository."
+msgstr "プロジェクトのgitリポジトリから依存関係を指定できます．"
+
+#: ../../pages/spec/manifest.md:454
+msgid "To use a specific upstream branch declare the *branch* name with"
+msgstr "特定の上流ブランチを利用するには，*branch*の名前を次のように宣言します．"
+
+#: ../../pages/spec/manifest.md:461
+msgid "Alternatively, reference tags by using the *tag* entry"
+msgstr "または，*tag*を用いてタグを参照します．"
+
+#: ../../pages/spec/manifest.md:468
+msgid "To pin a specific revision specify the commit hash in the *rev* entry"
+msgstr "特定のリビジョンに固定するには，*rev*にコミットハッシュを指定します．"
+
+#: ../../pages/spec/manifest.md:475
+msgid ""
+"For more verbose layout use normal tables rather than inline tables to "
+"specify dependencies"
+msgstr ""
+"インラインではなく通常のテーブルを利用すると，"
+"より冗長なレイアウトで依存関係が指定できます．"
+
+#: ../../pages/spec/manifest.md:484
+msgid "Development dependencies"
+msgstr "開発時の依存関係の指定"
+
+#: ../../pages/spec/manifest.md:486
+msgid ""
+"Development dependencies allow to declare *dev-dependencies* in the "
+"manifest root, which are available to all tests but not exported with the"
+" project."
+msgstr ""
+"開発時の依存関係は，マニフェスト直下の*dev-dependencies*設定項目で宣言できます．"
+"これは全てのテストで利用できますが，他のプロジェクトには展開されません．"
+
+#: ../../pages/spec/manifest.md:489
+msgid "Installation configuration"
+msgstr "インストール設定"
+
+#: ../../pages/spec/manifest.md:491
+msgid ""
+"In the *install* section components for the installation can be selected."
+" By default only executables are installed, library projects can set the "
+"*library* boolean to also installatation the module files and the "
+"archive."
+msgstr ""
+"*install*設定項目では，インストールする対象を選択できます．"
+"標準では，実行ファイルのみがインストールされます．ライブラリを作成するプロジェクトでは，"
+"*library*に真値を設定することで，モジュールファイルやアーカイブもインストールする"
+"ように設定できます．"
+
+#: ../../pages/spec/manifest.md:494
+msgid "*Example*"
+msgstr "**例**"
+
+#: ../../pages/spec/manifest.md:502
+msgid "Additional free data field"
+msgstr "設定の追加欄"
+
+#: ../../pages/spec/manifest.md:504
+msgid ""
+"Third-party tools can store their configuration inside the *extra* "
+"section. This section will never be evaluated by fpm itself, the only "
+"constraint imposed is that it has to be valid TOML."
+msgstr ""
+"*extra*設定項目内に，第三者製ツールの設定を記述できます．"
+"この設定項目は，fpmによって評価はされません．"
+"正当なTOML形式であることが唯一の制約です．"
+
+#: ../../pages/spec/manifest.md:507
+msgid ""
+"Since the format of this section is free, only recommendations are "
+"provided here for adding data to the *extra* section."
+msgstr ""
+"この項目の書式は自由なので，ここでは*extra*に追加するデータの推奨事項"
+"のみを示します．"
+
+#: ../../pages/spec/manifest.md:509
+msgid ""
+"Only use subtables, never add configuration data to the top level of the "
+"*extra* section. Reasoning: different tools can avoid collisions of key "
+"names by placing their data in separate subtables."
+msgstr ""
+"サブテーブルのみを使用し，*extra*に設定を追加してはならない．"
+"根拠：異なるツールが参照するデータを個々のサブテーブルに配置することで，"
+"名前の衝突を避けることができる．"
+
+#: ../../pages/spec/manifest.md:511
+msgid ""
+"Use the concrete name of the tool rather than a generic name for the "
+"subtable. Reasoning: different formatter or linter tools might use "
+"conflicting keywords in a *format* or *lint* subtable. Also, users can "
+"tell from the table name which tool is preferred to use with the project."
+msgstr ""
+"サブテーブルには，一般的な名前ではなく，ツールの具体的な名前を用いる．"
+"根拠：異なるフォーマッタやリンタが，*format*あるいは*lint*サブテーブル内で"
+"相反するキーワードを使用する可能性がある．また，どのツールをプロジェクトで"
+"利用するのが適切かを，ユーザがテーブルの名前から判断できる．"
+
+#: ../../pages/spec/manifest.md:514
+msgid ""
+"Fpm plugins should use a subtable with their plugin name in the "
+"*extra.fpm* section to store their data. Reasoning: following this "
+"convention provides the user of fpm plugins with one section to configure"
+" their used plugins."
+msgstr ""
+"fpmのプラグインは，*extra.fpm*項目内でプラグイン名を持つ"
+"サブテーブルを使用してデータを格納する．根拠：この規約に従うことで，"
+"利用するプラグインの設定が書かれた単一の設定項目をユーザに提供できる．"
+
+#: ../../pages/spec/manifest.md:516
+msgid ""
+"Use the fpm preferred style for keywords which is lowercase with dashes. "
+"Reasoning: while there is no style check in this section, a consistent "
+"style in the whole manifest will make it easier for the user to "
+"understand the whole package manifest."
+msgstr ""
+"キーワードの記述には，小文字とダッシュで構成されるfpmのスタイルを使用する．"
+"根拠：この設定項目の書式はチェックされないが，マニフェスト全体で一貫した書式を"
+"維持することにより，ユーザがパッケージマニフェスト全体を理解しやすくなる．"
+
+#: ../../pages/spec/manifest.md:519
+msgid ""
+"Feedback for the recommendations above is very much welcome. If you have "
+"a tool that uses the *extra* section in the package manifest, feel free "
+"to post it in at the [fpm discussion board](https://github.com/fortran-"
+"lang/fpm/discussions)."
+msgstr ""
+"上記推奨事項に対する反応を歓迎します．"
+"もしあなたがパッケージマニフェストの*extra*設定項目を使用するツールをお持ちの場合は，"
+"[fpmディスカッション掲示板](https://github.com/fortran-lang/fpm/discussions)に"
+"その情報を投稿してください．"

--- a/locale/ja/LC_MESSAGES/spec.po
+++ b/locale/ja/LC_MESSAGES/spec.po
@@ -246,8 +246,8 @@ msgid ""
 "License](https://www.gnu.org/licenses/lgpl-3.0-standalone.html), either "
 "version 3 or any later version, is specified as"
 msgstr ""
-"[GNU Lesser General Public License]のバージョン3もしくはそれ以降"
-"(https://www.gnu.org/licenses/lgpl-3.0-standalone.html)"
+"[GNU Lesser General Public License](https://www.gnu.org/licenses/lgpl-3.0-standalone.html)"
+"のバージョン3もしくはそれ以降"
 "の下で許諾されるプロジェクトは，次のように指定します．"
 
 #: ../../pages/spec/manifest.md:107

--- a/locale/ja/LC_MESSAGES/sphinx.po
+++ b/locale/ja/LC_MESSAGES/sphinx.po
@@ -1,0 +1,83 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 Fortran programming language community
+# This file is distributed under the same license as the fpm package.
+# Tomohiro Degawa <degawa.tomohiro@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: fpm \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-20 15:35+0900\n"
+"PO-Revision-Date: 2022-03-22 20:59+0900\n"
+"Last-Translator: 出川智啓 <degawa.tomohiro@gmail.com>\n"
+"Language-Team: degawa <https://github.com/degawa>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/archives.html:3
+msgid "Archives"
+msgstr "史料"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/authors.html:2
+msgid "Authors"
+msgstr "著者"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/categories.html:3
+msgid "Categories"
+msgstr "分類"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/collection.html:47
+msgid "Read more ..."
+msgstr "続きを読む"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/languages.html:3
+msgid "Languages"
+msgstr "言語"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/locations.html:3
+msgid "Locations"
+msgstr "場所"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postcard2.html:5
+msgid "Update"
+msgstr "更新"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postcard2.html:12
+msgid "Author"
+msgstr "著者"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postcard2.html:24
+msgid "Location"
+msgstr "場所"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postcard2.html:35
+msgid "Language"
+msgstr "言語"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postcard2.html:46
+msgid "Category"
+msgstr "分類"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postcard2.html:57
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/tagcloud.html:2
+msgid "Tags"
+msgstr "タグ"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postcard2.html:60
+msgid "Tag"
+msgstr "タグ"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postnavy.html:5
+msgid "Previous"
+msgstr "前へ"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/postnavy.html:15
+msgid "Next"
+msgstr "次へ"
+
+#: ../../../../.venv/fpm-doc/lib/python3.8/site-packages/ablog/templates/recentposts.html:3
+msgid "Recent Posts"
+msgstr "最近の投稿"

--- a/locale/ja/LC_MESSAGES/tutorial.po
+++ b/locale/ja/LC_MESSAGES/tutorial.po
@@ -1,0 +1,457 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 Fortran programming language community
+# This file is distributed under the same license as the fpm package.
+# Tomohiro Degawa <degawa.tomohiro@gmail.com>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: fpm \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-20 15:35+0900\n"
+"PO-Revision-Date: 2022-03-22 20:59+0900\n"
+"Last-Translator: 出川智啓 <degawa.tomohiro@gmail.com>\n"
+"Language-Team: degawa <https://github.com/degawa>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../pages/tutorial/dependencies.md:1
+msgid "Adding dependencies"
+msgstr "依存関係の追加"
+
+#: ../../pages/tutorial/dependencies.md:3
+msgid ""
+"This tutorial covers the usage of dependencies with fpm and how to reuse "
+"existing fpm projects."
+msgstr ""
+"ここでは，fpmによる依存関係の利用方法と，"
+"既存のfpmプロジェクトを再利用する方法を取り扱います．"
+
+#: ../../pages/tutorial/dependencies.md:5
+msgid "Using the standard library"
+msgstr "標準ライブラリの利用"
+
+#: ../../pages/tutorial/dependencies.md:7
+msgid ""
+"We start with a new project with fpm, we want to build a command line "
+"application to read a file, find a certain pattern and replace it. Since "
+"we do not want to write the replace function ourselves, we will use the "
+"Fortran standard library ([stdlib](https://github.com/fortran-"
+"lang/stdlib)) as dependency. In the package manifest we define *stdlib* "
+"in the *dependencies* table:"
+msgstr ""
+"fpmを用いて新規プロジェクトを開始し，ファイルを読み込んで特定のパターンを見つけ，"
+"それを置換するコマンドラインアプリケーションを構築することにします．"
+"置換する関数を書きたくないので，Fortran標準ライブラリ"
+"（[stdlib](https://github.com/fortran-lang/stdlib)）を依存関係として利用します．"
+"パッケージマニフェスト内の*dependencies*設定項目で，*stdlib*を定義します．"
+
+#: ../../pages/tutorial/dependencies.md:11
+#: ../../pages/tutorial/dependencies.md:77
+#: ../../pages/tutorial/dependencies.md:112
+#: ../../pages/tutorial/hello-fpm.md:33
+msgid "fpm.toml"
+msgstr ""
+
+#: ../../pages/tutorial/dependencies.md:18
+msgid ""
+"Now we create a module with a procedure to perform the substitution. It "
+"requires three steps:"
+msgstr ""
+"差し替えを実行する手続をもつモジュールを作成します．"
+"これには，三つの段階が必要です．"
+
+#: ../../pages/tutorial/dependencies.md:21
+msgid "reading a whole line from one unit"
+msgstr "一つの装置から1行を読み込み"
+
+#: ../../pages/tutorial/dependencies.md:22
+msgid "replace the pattern in the string"
+msgstr "文字列内の特定のパターンを置き換え"
+
+#: ../../pages/tutorial/dependencies.md:23
+msgid "write the new string to an output"
+msgstr "出力に新しい文字列を書き出し"
+
+#: ../../pages/tutorial/dependencies.md:25
+msgid ""
+"We will use the *replace\\_all* function from the *stdlib\\_strings* "
+"module for this purpose. The implementation is shown here"
+msgstr ""
+"これを実現するために，*stdlib\\_strings*モジュールにある"
+"*replace\\_all*関数を用います．実装を以下に示します．"
+
+
+#: ../../pages/tutorial/dependencies.md:28
+msgid "src/demo.f90"
+msgstr ""
+
+#: ../../pages/tutorial/dependencies.md:33
+msgid "Finally, we need a command line driver to make use of our new function."
+msgstr "最後に，作成した新しい手続を使えるようにするために，コマンドラインから呼び出すメインルーチンが必要です．"
+
+#: ../../pages/tutorial/dependencies.md:35
+#: ../../pages/tutorial/dependencies.md:125
+#: ../../pages/tutorial/hello-fpm.md:52
+msgid "app/main.f90"
+msgstr ""
+
+#: ../../pages/tutorial/dependencies.md:54
+msgid "We can check our command line driver by running it with fpm:"
+msgstr "fpmを用いてメインルーチンを呼び出し，動作を確認します．"
+
+#: ../../pages/tutorial/dependencies.md:68
+msgid "Adding a testing framework"
+msgstr "テストフレームワークの追加"
+
+#: ../../pages/tutorial/dependencies.md:70
+msgid ""
+"Before we continue implementing new features, we want to add some tests "
+"to verify that our implementation keeps worked as we modify it. A "
+"minimalist testing framework is available with [test-drive]. Since the "
+"testing framework is only required when developing the package itself, "
+"but not for other packages which might in the future make use of our "
+"modules, we add a local dependency. The *test-drive* package is added in "
+"the *dev-dependencies* table as shown below"
+msgstr ""
+"新機能の実装を継続する前に，いくつかテストを追加して，"
+"実装を変更しても動作し続けることを確認します．"
+"[test-drive](https://github.com/fortran-lang/test-drive)を用いることで，"
+"最小限のテストフレームワークが利用できるようになります．"
+"テストフレームワークはパッケージを開発するときにのみ必要で，"
+"将来的に作成するであろう他のパッケージには必要ないので，限定的な依存関係として追加します．"
+"*test-drive*パッケージを，下記に示すように，*dev-dependencies*設定項目に追加します．"
+
+#: ../../pages/tutorial/dependencies.md:85
+msgid ""
+"For a development dependency like a testing framework we choose a strict "
+"version pin by specifying the *tag* we want to use."
+msgstr ""
+"テストフレームワークのような開発時に参照する依存関係に対しては，"
+"タグを指定して，使用したい厳密なバージョンを選択します．"
+
+#: ../../pages/tutorial/dependencies.md:88
+msgid ""
+"Now we can write a simple unit test, since our function works with units,"
+" we will create scratch units to create the input and capture the output."
+" For now we will add a simple one line substitution as single test case"
+msgstr ""
+"ここで作成している関数はそれ単体で動作するため，単純な単体テストを記述できます．"
+"入力を生成して出力を取得する単体機能を作成することにします．"
+"とりあえず，単純な1行の差し替えを，一つのテストケースとして追加します．"
+
+#: ../../pages/tutorial/dependencies.md:91
+msgid "test/main.f90"
+msgstr ""
+
+#: ../../pages/tutorial/dependencies.md:96
+msgid "We run our new test using fpm"
+msgstr "fpmを用いて作成したテストを実行します．"
+
+#: ../../pages/tutorial/dependencies.md:104
+msgid ""
+"Creating the scratch units for multiple unit tests will be repetitive, "
+"this kind of tasks can usually be done in a separate procedure and reused"
+" in several tests."
+msgstr ""
+"複数の単体テストにおける単体機能の作成は，反復的な作業になります．"
+"この種の作業は通常，独立した手順で行うことができ，いくつかのテストで再利用されます．"
+
+#: ../../pages/tutorial/dependencies.md:107
+msgid "Target-specific dependencies"
+msgstr "ビルド対象固有の依存関係"
+
+#: ../../pages/tutorial/dependencies.md:109
+msgid ""
+"Dependencies can also be used for specific targets only. This can be used"
+" for adding a command line interface package, which is only used for the "
+"executable but not part of the library dependencies."
+msgstr ""
+"依存関係は，特定のビルド対象に対してのみ利用できます．"
+"ここで導入するビルド対象固有の依存関係は，"
+"実行ファイルにコマンドラインインタフェースを追加するパッケージであって，"
+"ライブラリの依存関係ではありません．"
+
+#: ../../pages/tutorial/dependencies.md:118
+msgid ""
+"We restructure our main program a bit for using [M\\_CLI2] to handle the "
+"command line input. The *unnamed* array contains all positional command "
+"line arguments, we still use the first two as pattern and replacement, "
+"and use all remaining arguments as input. We also add an option to "
+"redirect the output. Our final main program looks like"
+msgstr ""
+"[M\\_CLI2](https://github.com/urbanjost/M_CLI2)を用いて"
+"コマンドライン入力を処理するために，メインルーチンを若干再構成します．"
+"配列*unnamed*は，位置関係を含むコマンドライン引数全てを保持しています．"
+"最初の二つをパターンと置換に利用し，残りの全ての引数を入力として用います．"
+"また，出力をリダイレクトするオプションも追加しました．"
+"最終的なメインルーチンは，次のようになりました．"
+
+#: ../../pages/tutorial/dependencies.md:130
+msgid "Again we run a quick check using fpm"
+msgstr "fpmを用いて簡単な確認を再度行います．"
+
+#: ../../pages/tutorial/dependencies.md:152
+msgid "The output looks as expected with two substitutions."
+msgstr "期待通りに2箇所の差し替えが行われました．"
+
+#: ../../pages/tutorial/dependencies.md:155
+#: ../../pages/tutorial/hello-fpm.md:97 ../../pages/tutorial/plugins.md:90
+msgid "Summary"
+msgstr "まとめ"
+
+#: ../../pages/tutorial/dependencies.md:157
+#: ../../pages/tutorial/hello-fpm.md:99 ../../pages/tutorial/plugins.md:92
+msgid "In this tutorial you learned how to"
+msgstr "ここでは以下の方法を学びました．"
+
+#: ../../pages/tutorial/dependencies.md:159
+msgid "depend on another fpm project in the package manifest"
+msgstr "パッケージマニフェスト内で別のfpmプロジェクトを参照する方法"
+
+#: ../../pages/tutorial/dependencies.md:160
+msgid "add development dependencies for testing"
+msgstr "テストのために開発時の依存関係を追加する方法"
+
+#: ../../pages/tutorial/dependencies.md:161
+msgid "use dependencies for executables"
+msgstr "実行ファイルに依存関係を追加する方法"
+
+#: ../../pages/tutorial/hello-fpm.md:1
+msgid "First steps with fpm"
+msgstr "fpm最初の一歩"
+
+#: ../../pages/tutorial/hello-fpm.md:3
+msgid ""
+"This tutorial covers the basic usage of the Fortran Package Manager (fpm)"
+" command line. It will cover the generation of a new project and the "
+"possibility to compile a project into an executable as well as the "
+"possibility to run the resulting program."
+msgstr ""
+"ここでは，コマンドラインにおけるFortranパッケージマネージャ（fpm）の"
+"基本的な使用方法を取り扱います．新規プロジェクトの作成や，"
+"プロジェクトを実行ファイルにコンパイルする方法だけでなく，構築されたプログラムを"
+"実行する方法についても取り扱います．"
+
+#: ../../pages/tutorial/hello-fpm.md:6
+msgid "To start a new project with fpm use the *fpm new* command"
+msgstr "fpmで新しいプロジェクトを始めるには，*fpm new*コマンドを用います．"
+
+#: ../../pages/tutorial/hello-fpm.md:12
+msgid ""
+"By default fpm creates a git repository with a dummy project in the fpm "
+"standard layout"
+msgstr ""
+"標準では，fpmは既定の構成をもつ仮プロジェクトを含んだgitリポジトリを作成します．"
+
+#: ../../pages/tutorial/hello-fpm.md:30
+msgid ""
+"This is everything we need to start our new project. First, we inspect "
+"the package manifest, ``fpm.toml``, which is populated with stub entries "
+"for us:"
+msgstr ""
+"これが，新しいプロジェクトを開始するために必要な全てです．最初に，"
+"パッケージマニフェストである``fpm.toml``を見てみましょう．"
+"``fpm.toml``には，仮データが記入されています．"
+
+#: ../../pages/tutorial/hello-fpm.md:49
+msgid ""
+"The package manifest contains all the required meta data for the new "
+"project. Next we checkout the main executable, ``app/main.f90``, fpm has "
+"generated for us:"
+msgstr ""
+"パッケージマニフェストには，新規プロジェクトに必要な全てのメタデータが含まれています．"
+"次に，fpmが生成した実行ファイル``app/main.f90``を確かめます．"
+
+#: ../../pages/tutorial/hello-fpm.md:62
+msgid ""
+"The program already uses a module from our library, which we can find in "
+"``src/first_steps.f90``:"
+msgstr ""
+"このプログラムは，既にライブラリからモジュールを`use`しています．"
+"当該のモジュールは，``src/first_steps.f90``で確認できます．"
+
+#: ../../pages/tutorial/hello-fpm.md:64
+msgid "src/first_steps.f90"
+msgstr ""
+
+#: ../../pages/tutorial/hello-fpm.md:78
+msgid "We can run the executable directly with the command ``fpm run``:"
+msgstr "``fpm run``コマンドによって，実行ファイルを直接実行できます．"
+
+#: ../../pages/tutorial/hello-fpm.md:86
+msgid ""
+"Similarly, fpm has already created a stub for testing, which can be "
+"invoked with ``fpm test``:"
+msgstr ""
+"同様に，fpmはテストのための仮ソースを作成済みであり，``fpm test``で呼び出せます．"
+
+#: ../../pages/tutorial/hello-fpm.md:94
+msgid ""
+"Fpm will automatically track changes in your project when running your "
+"project using the *run* and *test* commands."
+msgstr ""
+"Fpmは，*run*や*test*サブコマンドによってプロジェクトを実行する際に，"
+"自動的にプロジェクトの変更を追跡します．"
+
+#: ../../pages/tutorial/hello-fpm.md:101
+msgid "create a new project from the fpm command line"
+msgstr "fpmコマンドラインから新規プロジェクトを作成する方法"
+
+#: ../../pages/tutorial/hello-fpm.md:102
+msgid "build and run your project executables with fpm"
+msgstr "fpmを用いてプロジェクトをビルドし，実行する方法"
+
+#: ../../pages/tutorial/hello-fpm.md:103
+msgid "run tests with fpm"
+msgstr "fpmを用いてテストを実行する方法"
+
+#: ../../pages/tutorial/index.md:3
+msgid "Tutorials"
+msgstr "実践手引"
+
+#: ../../pages/tutorial/index.md:6
+msgid ""
+"This section contains courses for learning about the usage and fpm at "
+"specific examples."
+msgstr ""
+"ここには，使用方法やfpmの具体的な事例を学ぶための教程を掲載しています．"
+
+#: ../../pages/tutorial/plugins.md:1
+msgid "Extending fpm with plugins"
+msgstr "プラグインによるfpmの拡張"
+
+#: ../../pages/tutorial/plugins.md:3
+msgid ""
+"The Fortran package manager has a plugin system which allows to easily "
+"extend its functionality. This tutorial will show how to install a plugin"
+" with fpm and use it."
+msgstr ""
+"Fortranパッケージマネージャにはプラグインシステムが備わっており，"
+"機能を容易に拡張できます．ここでは，プラグインをインストールし，"
+"使用する方法を示します．"
+
+#: ../../pages/tutorial/plugins.md:7
+msgid "Registry search tool"
+msgstr "レジストリ検索ツール"
+
+#: ../../pages/tutorial/plugins.md:9
+msgid ""
+"The [fpm-search](https://github.com/urbanjost/fpm-search) project is a "
+"plugin to query the package registry. Since it is built with fpm we can "
+"easily install it on our system with"
+msgstr ""
+"[fpm-search](https://github.com/urbanjost/fpm-search)プロジェクトは"
+"パッケージが登録されているfpmレジストリを照会するためのプラグインです．"
+"fpmとともにビルドされているので，以下のように簡単にシステムにインストールできます．"
+
+#: ../../pages/tutorial/plugins.md:18
+msgid ""
+"This will install the ``fpm-search`` binary to ``~/.local/bin`` (or "
+"``%APPDATA%\\local\\bin`` on Windows)."
+msgstr ""
+"``fpm-search``のバイナリが``~/.local/bin``（Windowsでは"
+"``%APPDATA%\\local\\bin``）にインストールされます．"
+
+#: ../../pages/tutorial/plugins.md:21
+msgid "Ensure that the installed binary is in the ``PATH``, *i.e.* run"
+msgstr "インストールされたバイナリが``PATH``内にあることを確認します．"
+"すなわち，次のコマンドを実行します．"
+
+#: ../../pages/tutorial/plugins.md:28
+msgid "If no binary is found, add the directory to your path using"
+msgstr "バイナリが見つからない場合は，インストールされたディレクトリをパスに追加します．"
+
+#: ../../pages/tutorial/plugins.md
+msgid "Bash (Linux)"
+msgstr ""
+
+#: ../../pages/tutorial/plugins.md:34
+msgid ""
+"Default settings for the bash shell can be found in the ``.bashrc`` file "
+"in the home directory, to append to the ``PATH`` following the "
+"instructions below."
+msgstr ""
+"bashシェルの標準設定は，ホームディレクトリにある``.bashrc``で確認できます．"
+"以下の手順で``PATH``に追加してください．"
+
+#: ../../pages/tutorial/plugins.md:41
+msgid ""
+"Make sure to source your ``.bashrc`` after changing it, otherwise the "
+"change will not be applied to the current shell."
+msgstr ""
+"``.bashrc``を変更した後，``.bashrc``を再読込してください．"
+"そうしないと，変更が現在のシェルに適用されません．"
+
+#: ../../pages/tutorial/plugins.md
+msgid "Zsh (MacOS)"
+msgstr ""
+
+#: ../../pages/tutorial/plugins.md:45
+msgid ""
+"Default settings for the zsh shell can be found in the ``.zshrc`` file in"
+" the home directory, to append to the ``PATH`` use"
+msgstr ""
+"zshシェルの標準設定はホームディレクトリの``.zshrc``で確認できます．"
+"下記コマンドを用いて``PATH``に追加してください．"
+
+#: ../../pages/tutorial/plugins.md:52
+msgid ""
+"Make sure to restart zsh after changing the ``.zshrc`` it, otherwise the "
+"change will not be applied to the current shell."
+msgstr ""
+"``.zshrc``を変更した後，zshを再起動してください．"
+"そうしないと，変更が現在のシェルに適用されません．"
+
+#: ../../pages/tutorial/plugins.md
+msgid "CMD (Windows)"
+msgstr ""
+
+#: ../../pages/tutorial/plugins.md:56
+msgid ""
+"The ``PATH`` variable can be modified using the pathman program from the "
+"cmd prompt"
+msgstr ""
+"``PATH``変数は，コマンドプロンプトからpathmanプログラムを利用して変更できます．"
+
+#: ../../pages/tutorial/plugins.md:64
+msgid "Now with a working installation we can invoke our new plugin from fpm."
+msgstr "インストールできたので，fpmから新しいプラグインを呼び出すことができます．"
+
+#: ../../pages/tutorial/plugins.md:72
+msgid ""
+"Note that we use ``fpm search`` rather than ``fpm-search`` in the "
+"command. To find a package for building a command-line interface we can "
+"now type"
+msgstr ""
+"コマンドには，``fpm-search``ではなく``fpm search``を用いていることに注意してください．"
+"コマンドラインインタフェースを構築するためのパッケージを見つけるには，次のように入力します．"
+
+#: ../../pages/tutorial/plugins.md:81
+msgid ""
+"To use one of the packages in our manifest we can generate the necessary "
+"dependency line by running"
+msgstr ""
+"パッケージを用いるために必要なマニフェストの依存関係の設定内容を，"
+"次のコマンドを実行して生成します．"
+
+#: ../../pages/tutorial/plugins.md:88
+msgid ""
+"Adding this line to a package manifest allows to depend on the respective"
+" project."
+msgstr ""
+"この一行をパッケージマニフェストに追加することで，当該のプロジェクトを参照できます．"
+
+#: ../../pages/tutorial/plugins.md:94
+msgid "installing an fpm plugin"
+msgstr "fpmプラグインをインストールする方法"
+
+#: ../../pages/tutorial/plugins.md:95
+msgid "use the fpm-search plugin to query the registry"
+msgstr "レジストリを照会するためにfpm-searchプラグインを使用する方法"
+
+#: ../../pages/tutorial/plugins.md:96
+msgid "generate a dependency entry from a query result"
+msgstr "照会結果から依存関係の設定を生成する方法"

--- a/pages/_templates/sbt-sidebar-footer.html
+++ b/pages/_templates/sbt-sidebar-footer.html
@@ -2,7 +2,7 @@
   <div class="navbar_extra_footer">
     <div class="sd-fs-6">
     ·
-    {%- for lang in ('zh_CN', 'de', 'en', 'es', 'fr', 'nl',) %}
+    {%- for lang in ('zh_CN', 'de', 'en', 'es', 'fr', 'ja', 'nl') %}
       {%- if lang == language %}
       <b>{{lang.lower()[-2:]}}</b>
       {%- else %}


### PR DESCRIPTION
To contribute to internationalizing the fpm-doc, I translated fpm-doc into Japanese.

Committed changes are as follows:
- [x] created .po files in `locale/ja`.
- [x] translated all the .po files into Japanese.
- [x] added `'ja'` like `{%- for lang in ('zh_CN', 'de', 'en', 'es', 'fr', 'ja', 'nl') %}` in `pages/_templates/sbt-sidebar-footer.html`.
- [x] added `ja` to `LANGUAGE` in Makefile.
- [x] generated pages using `make html` and confirmed those via some browsers.

A review by other Japanese speakers is needed.
I plan to ask for a review when the page preview is available and will reflect corrections.

---

The page preview is available via https://degawa.github.io/fpm-docs/ja/index.html
