### PR TITLE
docs: add installation instructions for fpm

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         gcc: [10]
 
     steps:

--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -1,0 +1,43 @@
+# Github action to cleanup a PR preview
+# Runs when a pull request is merged or comment contains '#delete_preview'
+#
+
+name: PR Preview Cleanup
+
+on:
+  issue_comment:
+    types: [created]
+
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true || contains(github.event.comment.body, '#delete-preview')
+
+    steps:
+      # Checkout existing gh-pages branch into PUBLISH_DIR
+      - name: Checkout gh-pages
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      # Cleanup preview files
+      - name: PR Cleanup
+        run: rm -rf pr/${{github.event.issue.number}}
+
+      - name: Commit and push to gh-pages
+        uses: EndBug/add-and-commit@v9.1.0
+        with:
+          message: "Sphinx build cleanup pr/${{github.event.issue.number}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Comment on pull request
+      - name: Comment on pull request
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{github.event.issue.number}}
+          body: The preview build for this PR has now been deleted.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,57 @@
+# Github action to build preview sphinx site and commit to gh-pages branch
+#  Built site is pushed to 'gh-pages' branch
+#
+
+name: Sphinx Preview Build
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '#preview')
+
+    steps:
+      - name: Checkout pr/${{github.event.issue.number}}
+        uses: actions/checkout@v3
+
+      - name: Fetch pr/${{github.event.issue.number}}
+        run: |
+          git fetch origin pull/${{github.event.issue.number}}/head:pr-${{github.event.issue.number}}
+          git checkout pr-${{github.event.issue.number}}
+
+      - name: Install dependencies
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: environment.yaml
+
+      - name: Safe workflow for build preview
+        run: if [ -d "_build" ]; then rm -rf _build; fi
+
+      - name: Build page and Translations
+        if: contains(github.event.comment.body, '#preview')
+        run: |
+          make gettext html
+
+      - name: Create nojekyll file
+        run: |
+          touch _build/.nojekyll
+
+      - name: Deploy documentation sphinx
+        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          target-folder: pr/${{github.event.issue.number}}
+          folder: _build/html
+          clean: false
+          git-config-email: 53436240+fortran-lang@users.noreply.github.com
+          git-config-name: Fortran
+
+      - name: Comment on pull request
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{github.event.issue.number}}
+          body: "This PR has been built with Sphinx and can be previewed at: https://fortran-lang.github.io/fpm/pr/${{github.event.issue.number}}"

--- a/README.md
+++ b/README.md
@@ -118,3 +118,9 @@ msgstr "This is "
 
 After adding or updating translations
 build the documentation as described above.
+
+## Pull Requests Previews
+
+You can build the Preview of the fpm-docs website by opening a pull request
+and commenting `#preview` on the pull request. Similarly, you can force the
+deletion of the preview by commenting `#delete-preview`.

--- a/pages/index.md
+++ b/pages/index.md
@@ -18,9 +18,6 @@ Package manager and build system for Fortran
 
 Welcome to the documentation for the Fortran Package Manager (fpm).
 
-This documentation is divided into four parts.
-Select one of the topics below to continue.
-
 ::::{note}
 These pages are currently under construction.
 Please help us improve them by contributing content or reporting issues.
@@ -36,6 +33,28 @@ Please help us improve them by contributing content or reporting issues.
 :class-body: sd-text-white
 :class-footer: sd-py-1 sd-border-0
 
+{octicon}`download` Install
+^^^
+
+Instructions on how to install fpm across Windows, Linux, macOS and more.
+
++++
+```{card}
+:link-type: ref
+:link: install
+:class-card: sd-btn sd-btn-light
+:class-body: sd-p-1 sd-text-center sd-font-weight-bold sd-text-info
+
+Install fpm
+```
+::::
+
+::::{grid-item-card}
+:class-header: sd-text-white sd-font-weight-bold sd-border-0
+:class-card: sd-text-white sd-bg-warning sd-rounded-3
+:class-body: sd-text-white
+:class-footer: sd-py-1 sd-border-0
+
 {octicon}`mortar-board` Tutorials
 ^^^
 
@@ -46,7 +65,7 @@ Learn about using fpm for Fortran development, creating projects and managing de
 :link-type: ref
 :link: tutorial
 :class-card: sd-btn sd-btn-light
-:class-body: sd-p-1 sd-text-center sd-font-weight-bold sd-text-info
+:class-body: sd-p-1 sd-text-center sd-font-weight-bold sd-text-warning
 
 Browse tutorials
 ```
@@ -54,7 +73,7 @@ Browse tutorials
 
 ::::{grid-item-card}
 :class-header: sd-text-white sd-font-weight-bold sd-border-0
-:class-card: sd-text-white sd-bg-warning sd-rounded-3
+:class-card: sd-text-white sd-bg-primary sd-rounded-3
 :class-body: sd-text-white
 :class-footer: sd-py-1 sd-border-0
 
@@ -68,31 +87,9 @@ Practical guides and recipes to solve specific problems with fpm
 :link-type: ref
 :link: how-to
 :class-card: sd-btn sd-btn-light
-:class-body: sd-p-1 sd-text-center sd-font-weight-bold sd-text-warning
-
-Browse recipes
-```
-::::
-
-::::{grid-item-card}
-:class-header: sd-text-white sd-font-weight-bold sd-border-0
-:class-card: sd-text-white sd-bg-primary sd-rounded-3
-:class-body: sd-text-white
-:class-footer: sd-py-1 sd-border-0
-
-{octicon}`milestone` Design Documents
-^^^
-
-Resources about the design of the command line interface, the package manifest, and the general user experience
-
-+++
-```{card}
-:link-type: ref
-:link: design
-:class-card: sd-btn sd-btn-light
 :class-body: sd-p-1 sd-text-center sd-font-weight-bold sd-text-primary
 
-Browse documents
+Browse recipes
 ```
 ::::
 
@@ -141,10 +138,11 @@ Recent events around the Fortran Package Manager, such as new releases, conferen
 ````{toctree}
 :maxdepth: 2
 :hidden:
+Installation <install/index>
 Tutorial <tutorial/index>
 How-To <how-to/index>
-Design <design/index>
 Reference <spec/index>
+Design <design/index>
 Registry <registry/index>
 news
 ````

--- a/pages/install/index.md
+++ b/pages/install/index.md
@@ -1,3 +1,5 @@
+(install)=
+
 # Installing fpm
 
 This how-to guide covers the installation of the Fortran Package Manager (fpm) on various platforms.
@@ -113,6 +115,27 @@ or from [miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
 [Conda]: https://conda.io
 [conda-forge]: https://conda-forge.org/
+
+
+## {fab}`apple` {fab}`linux` Spack package manager
+
+Fpm is available with spack in its develop version.
+To install fpm from spack use
+
+```{code-block}sh
+spack install fpm
+```
+
+You can add `+openmp` to enable parallelization of the target compilation in fpm.
+To use fpm in your environment load it with
+
+```{code-block}sh
+spack load fpm
+```
+
+For more details check the package information [here](https://spack.readthedocs.io/en/latest/package_list.html#fpm).
+
+[Spack]: https://spack.io
 
 
 ## {fab}`linux` Arch Linux user repository


### PR DESCRIPTION
Linked to https://github.com/fortran-lang/fpm/pull/778. Moved installation instructions to fpm-docs from README.

## Summary

Included also spack in the installation document.

Also, rearranged the grid in the main page
to have a offer installation prior to entering the
Tutorial section.

The How-To section is now empty, not sure if it's needed.