### PR TITLE
Fix macOS CI due to deleted gcc-9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,17 @@ jobs:
       run: |
         brew install gcc@${{ matrix.gcc }}
         ln -s /usr/local/bin/gfortran-${{ matrix.gcc }} /usr/local/bin/gfortran
+        # Backport gfortran shared libraries to version 9 folder. This is necessary because all macOS releases of fpm 
+        # have these paths hardcoded in the executable (no PIC?). As the gcc ABIs have not changed from 9 to 10, we 
+        # can just create symbolic links for now. This can be removed when an updated fpm release is built with gcc-10  
+        mkdir /usr/local/opt/gcc@9
+        mkdir /usr/local/opt/gcc@9/lib
+        mkdir /usr/local/opt/gcc@9/lib/gcc
+        mkdir /usr/local/opt/gcc@9/lib/gcc/9
+        mkdir /usr/local/lib/gcc/9
+        ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libquadmath.0.dylib /usr/local/opt/gcc@9/lib/gcc/9/libquadmath.0.dylib 
+        ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libgfortran.5.dylib /usr/local/opt/gcc@9/lib/gcc/9/libgfortran.5.dylib
+        ln -fs /usr/local/lib/gcc/${GCC_V}/libgcc_s.1.dylib /usr/local/lib/gcc/9/libgcc_s.1.dylib
 
     - name: Install GFortran (Linux)
       if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,9 +29,9 @@ jobs:
         mkdir /usr/local/opt/gcc@9/lib/gcc
         mkdir /usr/local/opt/gcc@9/lib/gcc/9
         mkdir /usr/local/lib/gcc/9
-        ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libquadmath.0.dylib /usr/local/opt/gcc@9/lib/gcc/9/libquadmath.0.dylib 
-        ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libgfortran.5.dylib /usr/local/opt/gcc@9/lib/gcc/9/libgfortran.5.dylib
-        ln -fs /usr/local/lib/gcc/${GCC_V}/libgcc_s.1.dylib /usr/local/lib/gcc/9/libgcc_s.1.dylib
+        ln -fs /usr/local/opt/gcc@${{ matrix.gcc }}/lib/gcc/${{ matrix.gcc }}/libquadmath.0.dylib /usr/local/opt/gcc@9/lib/gcc/9/libquadmath.0.dylib 
+        ln -fs /usr/local/opt/gcc@${{ matrix.gcc }}/lib/gcc/${{ matrix.gcc }}/libgfortran.5.dylib /usr/local/opt/gcc@9/lib/gcc/9/libgfortran.5.dylib
+        ln -fs /usr/local/lib/gcc/${{ matrix.gcc }}/libgcc_s.1.dylib /usr/local/lib/gcc/9/libgcc_s.1.dylib
 
     - name: Install GFortran (Linux)
       if: ${{ contains(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
Issue: gcc-9 was deleted from Github's macOS images (only last 3 revisions retained).

Solution: same as [fpm#861](https://github.com/fortran-lang/fpm/pull/861). gcc-9 libs are hardcoded in fpm. Until the bootstrapping fpm version can be updated to one that was built with gcc-10, create symbolic links to the locations requested by fpm executable (no ABI changes in libgfortran)